### PR TITLE
health_check probe added to annotations

### DIFF
--- a/templates/helm_overrides_values.yaml.tpl
+++ b/templates/helm_overrides_values.yaml.tpl
@@ -28,6 +28,7 @@ tfe:
 service:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /_health_check
     service.beta.kubernetes.io/azure-load-balancer-ipv4: "<lb-static-ip>" # Available private IP address from TFE load balancer subnet
 %{ if tfe_lb_subnet_name != "" ~}
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "${tfe_lb_subnet_name}"


### PR DESCRIPTION
## Description
With the helm release of 1.3.1 of TFE there is a change where the health probe is https. This fails Terraform Enterprise health check. 

There is an internal bug looking if this will stay the default.  Internal [IPL-7384](https://hashicorp.atlassian.net/browse/IPL-7384)

It doesn't hurt to have the health check properly pointing to correct URI

## Related issue
n/a

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Found the issue in my own code. Been asked by the implementation team Alex to create a PR for this. 

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
n/a


[IPL-7384]: https://hashicorp.atlassian.net/browse/IPL-7384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ