### PR TITLE
feat: add managed Redis support to the AKS module and update to TFE >1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@
 *.tfstate.*
 
 # Ignore all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -49,3 +49,5 @@ local_*.yaml
 
 # Ignore module-generated Helm overrides file
 module_generated_helm_overrides.yaml
+
+/tmp/**

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
   - Allow the creation of private endpoints (`private_endpoint_network_policies_enabled` = `false`)
   - Service delegation configured for PostgreSQL flexible servers (`Microsoft.DBforPostgreSQL/flexibleServers`) for join action (`Microsoft.Network/virtualNetworks/subnets/join/action`)
   - Service endpoint configured for `Microsoft.Storage`
-- Redis subnet ID for Azure cache for Redis. The Redis subnet should be configured to allow the creation of private endpoints (`private_endpoint_network_policies_enabled` = `false`)
+- Redis subnet ID for the Redis service used by TFE. The Redis subnet should be configured to allow the creation of private endpoints (`private_endpoint_network_policies_enabled` = `false`)
 
 #### Network security group (NSG)/firewall rules
 
@@ -37,7 +37,9 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
 - (Optional) Allow `TCP/9091` (HTTPS) and/or `TCP/9090` (HTTP) ingress to AKS/TFE pods subnet from CIDR ranges of your monitoring/observability tool (for scraping TFE metrics endpoints)
 - Allow `TCP/8443` (HTTPS) and `TCP/8080` (HTTP) ingress to AKS/TFE pods subnet from TFE load balancer subnet (for TFE application traffic)
 - Allow `TCP/5432` ingress to database subnet from AKS/TFE pods subnet (for PostgreSQL traffic)
-- Allow `TCP/6380` ingress to Redis cache subnet from AKS/TFE pods subnet (for Redis TLS traffic)
+- Allow Redis TLS ingress from the AKS/TFE pods subnet to the Redis subnet:
+  - `TCP/6380` for the legacy Azure Cache for Redis path
+  - `TCP/10000` for Azure Managed Redis when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`
 - Allow `TCP/8201` between nodes on AKS/TFE pods subnet (for TFE embedded Vault internal cluster traffic)
 - Allow `TCP/443` egress to Terraform endpoints listed [here](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/requirements/network#egress) from AKS/TFE pods subnet
 
@@ -120,7 +122,11 @@ If you plan to create a new AKS cluster using this module, then you may skip thi
 
 9. Create the required secrets for your TFE deployment within your new Kubernetes namespace for TFE. There are several ways to do this, whether it be from the CLI via `kubectl`, or another method involving a third-party secrets helper/tool. See the [kubernetes-secrets](./docs/kubernetes-secrets.md) docs for details on the required secrets and how to create them.
 
+    >📝 Note: If `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`, the module provisions Azure Managed Redis for both the primary TFE Redis connection and the Sidekiq Redis connection. In that case you must also create a `TFE_REDIS_SIDEKIQ_PASSWORD` secret value from the corresponding Terraform output. The generated Helm overrides also set the required Azure Managed Redis usernames (`TFE_REDIS_USER=default` and `TFE_REDIS_SIDEKIQ_USER=default`) automatically, and the managed Redis databases are created with the `EnterpriseCluster` clustering policy so TFE uses the Managed Redis topology intended for standard Redis clients instead of the redirecting `OSSCluster` mode.
+
 10. This Terraform module will automatically generate a Helm overrides file within your Terraform working directory named `./helm/module_generated_helm_overrides.yaml`. This Helm overrides file contains values interpolated from some of the infrastructure resources that were created by Terraform in step 6. Within the Helm overrides file, update or validate the values for the remaining settings that are enclosed in the `<>` characters. You may also add any additional configuration settings into your Helm overrides file at this time (see the [helm-overrides](./docs/helm-overrides.md) doc for more details).
+
+    >📝 Note: The generated file now derives `image.tag`, the Azure load balancer health probe path, and any Sidekiq Redis environment variables from the `tfe_image_tag` value used during `terraform apply`.
 
 11. Now that you have customized your `module_generated_helm_overrides.yaml` file, rename it to something more applicable to your deployment, such as `prod_tfe_overrides.yaml` (or whatever you prefer). Then, within your `terraform.tfvars` file, set the value of `create_helm_overrides_file` to `false`, as we no longer want the Terraform module to manage this file or generate a new one on a subsequent Terraform run.
 
@@ -175,8 +181,14 @@ If you plan to create a new AKS cluster using this module, then you may skip thi
 16. Verify the TFE application is ready:
 
     ```shell
+    # calver releases and semver releases earlier than 1.2.1
     curl https://<TFE_FQDN>/_health_check
+
+    # semver releases 1.2.1 and later
+    curl https://<TFE_FQDN>/api/v1/health/readiness?timeout=45
     ```
+
+    >📝 Note: The module-generated Helm overrides file automatically switches the Azure load balancer health probe path based on `tfe_image_tag`, so your readiness check here should match the TFE version you deployed.
 
 17. Follow the remaining steps [here](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/kubernetes/install#4-create-initial-admin-user) to finish the installation setup, which involves creating the **initial admin user**.
 
@@ -206,14 +218,14 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.60 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.60 |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
 ## Resources
@@ -224,6 +236,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [azurerm_federated_identity_credential.tfe_kube_service_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_kubernetes_cluster.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
+| [azurerm_managed_redis.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis) | resource |
+| [azurerm_managed_redis.tfe_sidekiq](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis) | resource |
 | [azurerm_postgresql_flexible_server.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
 | [azurerm_postgresql_flexible_server_configuration.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
@@ -256,10 +270,20 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL flexible server database. | `string` | n/a | yes |
+| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all Azure resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
+| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for the Redis service used by TFE. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of resource group for this TFE deployment. Must be an existing resource group if `create_resource_group` is `false`. | `string` | n/a | yes |
+| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should eventually resolve to the TFE load balancer DNS name or IP address and will be what clients use to access TFE. | `string` | n/a | yes |
+| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 | <a name="input_aks_api_server_authorized_ip_ranges"></a> [aks\_api\_server\_authorized\_ip\_ranges](#input\_aks\_api\_server\_authorized\_ip\_ranges) | List of IP ranges that are allowed to access the AKS API server (control plane). | `list(string)` | `[]` | no |
 | <a name="input_aks_default_node_pool_max_surge"></a> [aks\_default\_node\_pool\_max\_surge](#input\_aks\_default\_node\_pool\_max\_surge) | The maximum number of nodes that can be added during an upgrade. | `string` | `"10%"` | no |
 | <a name="input_aks_default_node_pool_name"></a> [aks\_default\_node\_pool\_name](#input\_aks\_default\_node\_pool\_name) | Name of default node pool. | `string` | `"default"` | no |
 | <a name="input_aks_default_node_pool_node_count"></a> [aks\_default\_node\_pool\_node\_count](#input\_aks\_default\_node\_pool\_node\_count) | Number of nodes to run in the AKS default node pool. | `number` | `2` | no |
+| <a name="input_aks_default_node_pool_temporary_name_for_rotation"></a> [aks\_default\_node\_pool\_temporary\_name\_for\_rotation](#input\_aks\_default\_node\_pool\_temporary\_name\_for\_rotation) | Temporary name Azure uses when rotating the AKS default node pool during updates that replace the existing pool. | `string` | `null` | no |
 | <a name="input_aks_default_node_pool_vm_size"></a> [aks\_default\_node\_pool\_vm\_size](#input\_aks\_default\_node\_pool\_vm\_size) | Size of the virtual machines within the AKS default node pool. | `string` | `"Standard_D8ds_v5"` | no |
 | <a name="input_aks_dns_service_ip"></a> [aks\_dns\_service\_ip](#input\_aks\_dns\_service\_ip) | The IP address assigned to the AKS internal DNS service. | `string` | `"10.1.0.10"` | no |
 | <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version for AKS cluster. | `string` | `"1.29.6"` | no |
@@ -278,15 +302,12 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_create_blob_storage_private_endpoint"></a> [create\_blob\_storage\_private\_endpoint](#input\_create\_blob\_storage\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for TFE Storage Account. | `bool` | `true` | no |
 | <a name="input_create_helm_overrides_file"></a> [create\_helm\_overrides\_file](#input\_create\_helm\_overrides\_file) | Boolean to generate a YAML file from template with Helm overrides values for TFE deployment. | `bool` | `true` | no |
 | <a name="input_create_postgres_private_endpoint"></a> [create\_postgres\_private\_endpoint](#input\_create\_postgres\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for PostgreSQL Flexible Server. | `bool` | `true` | no |
-| <a name="input_create_redis_private_endpoint"></a> [create\_redis\_private\_endpoint](#input\_create\_redis\_private\_endpoint) | Boolean to create a private DNS zone and private endpoint for Redis cache. | `bool` | `true` | no |
+| <a name="input_create_redis_private_endpoint"></a> [create\_redis\_private\_endpoint](#input\_create\_redis\_private\_endpoint) | Boolean to create a private DNS zone and private endpoint for the Redis service used by TFE. | `bool` | `true` | no |
 | <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new resource group for this TFE deployment. | `bool` | `true` | no |
 | <a name="input_create_tfe_private_dns_record"></a> [create\_tfe\_private\_dns\_record](#input\_create\_tfe\_private\_dns\_record) | Boolean to create a DNS record for TFE in a private Azure DNS zone. A `private_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
 | <a name="input_create_tfe_public_dns_record"></a> [create\_tfe\_public\_dns\_record](#input\_create\_tfe\_public\_dns\_record) | Boolean to create a DNS record for TFE in a public Azure DNS zone. A `public_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
-| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL flexible server database. | `string` | n/a | yes |
-| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all Azure resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
 | <a name="input_is_govcloud_region"></a> [is\_govcloud\_region](#input\_is\_govcloud\_region) | Boolean indicating if this TFE deployment is in an Azure Government Cloud region. | `bool` | `false` | no |
 | <a name="input_is_secondary_region"></a> [is\_secondary\_region](#input\_is\_secondary\_region) | Boolean indicating whether this TFE deployment is for 'primary' region or 'secondary' region. | `bool` | `false` | no |
-| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
 | <a name="input_postgres_backup_retention_days"></a> [postgres\_backup\_retention\_days](#input\_postgres\_backup\_retention\_days) | Number of days to retain backups of PostgreSQL Flexible Server. | `number` | `35` | no |
 | <a name="input_postgres_create_mode"></a> [postgres\_create\_mode](#input\_postgres\_create\_mode) | Determines if the PostgreSQL Flexible Server is being created as a new server or as a replica. | `string` | `"Default"` | no |
 | <a name="input_postgres_enable_high_availability"></a> [postgres\_enable\_high\_availability](#input\_postgres\_enable\_high\_availability) | Boolean to enable `ZoneRedundant` high availability with PostgreSQL database. | `bool` | `false` | no |
@@ -301,28 +322,26 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_private_dns_zone_rg_name"></a> [private\_dns\_zone\_rg\_name](#input\_private\_dns\_zone\_rg\_name) | Name of Resource Group where `private_dns_zone_name` resides. Required when `create_tfe_private_dns_record` is `true`. | `string` | `null` | no |
 | <a name="input_public_dns_zone_name"></a> [public\_dns\_zone\_name](#input\_public\_dns\_zone\_name) | Name of existing public Azure DNS zone to create DNS record in. Required when `create_tfe_public_dns_record` is `true`. | `string` | `null` | no |
 | <a name="input_public_dns_zone_rg_name"></a> [public\_dns\_zone\_rg\_name](#input\_public\_dns\_zone\_rg\_name) | Name of Resource Group where `public_dns_zone_name` resides. Required when `public_dns_zone_name` is not `null`. | `string` | `null` | no |
-| <a name="input_redis_capacity"></a> [redis\_capacity](#input\_redis\_capacity) | The size of the Redis cache to deploy. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4. | `number` | `1` | no |
-| <a name="input_redis_enable_authentication"></a> [redis\_enable\_authentication](#input\_redis\_enable\_authentication) | Boolean to enable authentication to the Redis cache. | `bool` | `true` | no |
-| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for Redis cache. | `bool` | `false` | no |
-| <a name="input_redis_family"></a> [redis\_family](#input\_redis\_family) | The SKU family/pricing group to use. Valid values are C (for Basic/Standard SKU family) and P (for Premium). | `string` | `"P"` | no |
-| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | Minimum TLS version to use with Redis cache. | `string` | `"1.2"` | no |
-| <a name="input_redis_sku_name"></a> [redis\_sku\_name](#input\_redis\_sku\_name) | Which SKU of Redis to use. Options are 'Basic', 'Standard', or 'Premium'. | `string` | `"Premium"` | no |
-| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for Azure cache for Redis. | `string` | n/a | yes |
-| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Redis cache version. Only the major version is needed. | `number` | `6` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of resource group for this TFE deployment. Must be an existing resource group if `create_resource_group` is `false`. | `string` | n/a | yes |
+| <a name="input_redis_capacity"></a> [redis\_capacity](#input\_redis\_capacity) | The size of the legacy Azure Cache for Redis deployment. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4. | `number` | `1` | no |
+| <a name="input_redis_enable_authentication"></a> [redis\_enable\_authentication](#input\_redis\_enable\_authentication) | Boolean to enable authentication to the Redis service used by TFE. | `bool` | `true` | no |
+| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for the legacy Azure Cache for Redis path. | `bool` | `false` | no |
+| <a name="input_redis_family"></a> [redis\_family](#input\_redis\_family) | The SKU family/pricing group to use for the legacy Azure Cache for Redis path. Valid values are C (for Basic/Standard SKU family) and P (for Premium). | `string` | `"P"` | no |
+| <a name="input_redis_managed_high_availability_enabled"></a> [redis\_managed\_high\_availability\_enabled](#input\_redis\_managed\_high\_availability\_enabled) | Boolean to enable high availability for Azure Managed Redis instances when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`. | `bool` | `true` | no |
+| <a name="input_redis_managed_sku_name"></a> [redis\_managed\_sku\_name](#input\_redis\_managed\_sku\_name) | Managed Redis SKU to use when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1` and the module switches to Azure Managed Redis. | `string` | `"Balanced_B3"` | no |
+| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | Minimum TLS version to use with the legacy Azure Cache for Redis path. | `string` | `"1.2"` | no |
+| <a name="input_redis_sku_name"></a> [redis\_sku\_name](#input\_redis\_sku\_name) | Which SKU of Redis to use for the legacy Azure Cache for Redis path. Options are 'Basic', 'Standard', or 'Premium'. | `string` | `"Premium"` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Legacy Azure Cache for Redis version. Only the major version is needed. | `number` | `6` | no |
 | <a name="input_secondary_aks_subnet_id"></a> [secondary\_aks\_subnet\_id](#input\_secondary\_aks\_subnet\_id) | AKS subnet ID of existing TFE AKS cluster in secondary region. Used to allow AKS TFE nodes in secondary region access to TFE storage account in primary region. | `string` | `null` | no |
 | <a name="input_storage_account_ip_allow"></a> [storage\_account\_ip\_allow](#input\_storage\_account\_ip\_allow) | List of CIDRs allowed to access TFE Storage Account. | `list(string)` | `[]` | no |
 | <a name="input_storage_account_public_network_access_enabled"></a> [storage\_account\_public\_network\_access\_enabled](#input\_storage\_account\_public\_network\_access\_enabled) | Boolean to enable public network access to Azure Blob Storage Account. Needs to be `true` for initial creation. Set to `false` after initial creation. | `bool` | `true` | no |
 | <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Which type of replication to use for TFE Storage Account. | `string` | `"ZRS"` | no |
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | PostgreSQL database name for TFE. | `string` | `"tfe"` | no |
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
-| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
-| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
 | <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of PostgreSQL TFE database user to create. | `string` | `"tfe"` | no |
 | <a name="input_tfe_dns_record_target"></a> [tfe\_dns\_record\_target](#input\_tfe\_dns\_record\_target) | Target of the TFE DNS record. This should be the IP address that the TFE FQDN resolves to. | `string` | `null` | no |
-| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should eventually resolve to the TFE load balancer DNS name or IP address and will be what clients use to access TFE. | `string` | n/a | yes |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8443` | no |
+| <a name="input_tfe_image_tag"></a> [tfe\_image\_tag](#input\_tfe\_image\_tag) | Tag for the TFE image. This may be a calver release tag, a semver release tag, or a Git commit hash and is used to select version-specific Helm readiness and Redis behavior. | `string` | `"v202402-1"` | no |
 | <a name="input_tfe_kube_namespace"></a> [tfe\_kube\_namespace](#input\_tfe\_kube\_namespace) | Kubernetes namespace for TFE deployment. | `string` | `"tfe"` | no |
 | <a name="input_tfe_kube_service_account"></a> [tfe\_kube\_service\_account](#input\_tfe\_kube\_service\_account) | Kubernetes service account for TFE deployment. | `string` | `"tfe"` | no |
 | <a name="input_tfe_lb_subnet_id"></a> [tfe\_lb\_subnet\_id](#input\_tfe\_lb\_subnet\_id) | Subnet ID for TFE load balancer. This can be the same as the AKS subnet ID if desired. The TFE load balancer is created/managed by Helm/Kubernetes. | `string` | `null` | no |
@@ -332,7 +351,6 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Name of existing resource group of TFE deployment in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
 | <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Name of existing TFE storage account in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
 | <a name="input_tfe_primary_storage_container_name"></a> [tfe\_primary\_storage\_container\_name](#input\_tfe\_primary\_storage\_container\_name) | Name of existing TFE storage container (within TFE storage account) in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
-| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -353,8 +371,12 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#output\_tfe\_object\_storage\_azure\_use\_msi) | Boolean indicating whether TFE is using a managed identity (MSI) to access the storage account. |
 | <a name="output_tfe_private_dns_record_fqdn"></a> [tfe\_private\_dns\_record\_fqdn](#output\_tfe\_private\_dns\_record\_fqdn) | Private DNS record for TFE. |
 | <a name="output_tfe_public_dns_record_fqdn"></a> [tfe\_public\_dns\_record\_fqdn](#output\_tfe\_public\_dns\_record\_fqdn) | Public DNS record for TFE. |
-| <a name="output_tfe_redis_host"></a> [tfe\_redis\_host](#output\_tfe\_redis\_host) | Hostname of the Redis cache. |
-| <a name="output_tfe_redis_password"></a> [tfe\_redis\_password](#output\_tfe\_redis\_password) | Primary access key of the Redis cache. |
-| <a name="output_tfe_redis_password_base64"></a> [tfe\_redis\_password\_base64](#output\_tfe\_redis\_password\_base64) | Base64-encoded primary access key of the Redis cache. |
-| <a name="output_tfe_redis_use_auth"></a> [tfe\_redis\_use\_auth](#output\_tfe\_redis\_use\_auth) | Boolean indicating whether TFE is using authentication to access the Redis cache. |
+| <a name="output_tfe_redis_host"></a> [tfe\_redis\_host](#output\_tfe\_redis\_host) | Hostname of the primary Redis service used by TFE. |
+| <a name="output_tfe_redis_password"></a> [tfe\_redis\_password](#output\_tfe\_redis\_password) | Primary access key of the primary Redis service used by TFE. |
+| <a name="output_tfe_redis_password_base64"></a> [tfe\_redis\_password\_base64](#output\_tfe\_redis\_password\_base64) | Base64-encoded primary access key of the primary Redis service used by TFE. |
+| <a name="output_tfe_redis_sidekiq_host"></a> [tfe\_redis\_sidekiq\_host](#output\_tfe\_redis\_sidekiq\_host) | Hostname of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected. |
+| <a name="output_tfe_redis_sidekiq_password"></a> [tfe\_redis\_sidekiq\_password](#output\_tfe\_redis\_sidekiq\_password) | Primary access key of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected. |
+| <a name="output_tfe_redis_sidekiq_password_base64"></a> [tfe\_redis\_sidekiq\_password\_base64](#output\_tfe\_redis\_sidekiq\_password\_base64) | Base64-encoded primary access key of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected. |
+| <a name="output_tfe_redis_sidekiq_use_auth"></a> [tfe\_redis\_sidekiq\_use\_auth](#output\_tfe\_redis\_sidekiq\_use\_auth) | Boolean indicating whether TFE is using authentication to access the Sidekiq Redis service when Azure Managed Redis is selected. |
+| <a name="output_tfe_redis_use_auth"></a> [tfe\_redis\_use\_auth](#output\_tfe\_redis\_use\_auth) | Boolean indicating whether TFE is using authentication to access the primary Redis service. |
 <!-- END_TF_DOCS -->

--- a/aks.tf
+++ b/aks.tf
@@ -14,12 +14,13 @@ resource "azurerm_kubernetes_cluster" "tfe" {
   kubernetes_version  = var.aks_kubernetes_version
 
   default_node_pool {
-    name           = var.aks_default_node_pool_name
-    node_count     = var.aks_default_node_pool_node_count
-    vm_size        = var.aks_default_node_pool_vm_size
-    os_sku         = "Ubuntu"
-    vnet_subnet_id = var.aks_subnet_id
-    zones          = var.availability_zones
+    name                        = var.aks_default_node_pool_name
+    node_count                  = var.aks_default_node_pool_node_count
+    vm_size                     = var.aks_default_node_pool_vm_size
+    temporary_name_for_rotation = var.aks_default_node_pool_temporary_name_for_rotation
+    os_sku                      = "Ubuntu"
+    vnet_subnet_id              = var.aks_subnet_id
+    zones                       = var.availability_zones
 
     upgrade_settings {
       max_surge = var.aks_default_node_pool_max_surge

--- a/blob_storage.tf
+++ b/blob_storage.tf
@@ -14,7 +14,7 @@ resource "azurerm_storage_account" "tfe" {
   account_tier                    = "Standard"
   access_tier                     = "Hot"
   account_replication_type        = var.storage_account_replication_type
-  enable_https_traffic_only       = true
+  https_traffic_only_enabled      = true
   min_tls_version                 = "TLS1_2"
   public_network_access_enabled   = var.storage_account_public_network_access_enabled
   allow_nested_items_to_be_public = false

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -35,7 +35,7 @@ tfe_image_tag = "1.2.1"
 Git commit hash:
 
 ```hcl
-tfe_image_tag = "sha-abc1234"
+tfe_image_tag = "abc1234"
 ```
 
 You can supply a calver release tag, a semver release tag, or a Git commit hash here.

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -20,8 +20,22 @@ create_aks_cluster = false
 
 Set `tfe_image_tag` to control the TFE application version that Terraform and the generated Helm overrides target:
 
+Calver release (default format):
+
 ```hcl
 tfe_image_tag = "v202502-1"
+```
+
+Semver release:
+
+```hcl
+tfe_image_tag = "1.2.1"
+```
+
+Git commit hash:
+
+```hcl
+tfe_image_tag = "sha-abc1234"
 ```
 
 You can supply a calver release tag, a semver release tag, or a Git commit hash here.

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -15,3 +15,15 @@ If you are bringing your own AKS cluster (module default):
 ```hcl
 create_aks_cluster = false
 ```
+
+## TFE version
+
+Set `tfe_image_tag` to control the TFE application version that Terraform and the generated Helm overrides target:
+
+```hcl
+tfe_image_tag = "v202502-1"
+```
+
+You can supply a calver release tag, a semver release tag, or a Git commit hash here.
+
+For commit-hash tags and semver releases `>= 1.0.1`, this input also switches the module to Azure Managed Redis with dedicated primary and Sidekiq Redis services. For commit-hash tags and semver releases `>= 1.2.1`, it also switches the generated health probe path to `/api/v1/health/readiness`.

--- a/docs/helm-overrides.md
+++ b/docs/helm-overrides.md
@@ -14,7 +14,9 @@ The module-generated `./helm/module_generated_helm_overrides.yaml` file derives 
 
 When Azure Managed Redis is selected, the generated file also renders:
 
+- `TFE_REDIS_USER` (set to `default` — required by Azure Managed Redis)
 - `TFE_REDIS_SIDEKIQ_HOST`
+- `TFE_REDIS_SIDEKIQ_USER` (set to `default` — required by Azure Managed Redis)
 - `TFE_REDIS_SIDEKIQ_USE_AUTH`
 - `TFE_REDIS_SIDEKIQ_USE_TLS`
 
@@ -70,6 +72,15 @@ service:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/api/v1/health/readiness"
 ```
+
+>📝 Note: The module-generated Helm overrides file always includes the `azure-load-balancer-ipv4: "<lb-static-ip>"` annotation (intended for internal LB deployments). When using a second Helm values file to override to an external load balancer, Helm deep-merges the two files, so that placeholder annotation will still be present and will cause the service controller to fail looking for a non-existent static IP. After `helm install` or `helm upgrade`, remove the annotation with:
+>
+> ```sh
+> kubectl annotate svc terraform-enterprise -n <TFE_NAMESPACE> \
+>   "service.beta.kubernetes.io/azure-load-balancer-ipv4-"
+> ```
+>
+> Alternatively, remove the `azure-load-balancer-ipv4` line directly from your `module_generated_helm_overrides.yaml` file before running Helm.
 
 ## Redis
 

--- a/docs/helm-overrides.md
+++ b/docs/helm-overrides.md
@@ -2,6 +2,28 @@
 
 This doc contains various customizations that are supported within your Helm overrides file for your TFE deployment.
 
+## Version-aware generated values
+
+The module-generated `./helm/module_generated_helm_overrides.yaml` file derives several values from `tfe_image_tag`:
+
+- `image.tag` is rendered directly from `tfe_image_tag`
+- the Azure load balancer health probe path stays on `/_health_check` for calver releases and semver releases earlier than `1.2.1`
+- the Azure load balancer health probe path switches to `/api/v1/health/readiness` for commit-hash tags and semver releases `>= 1.2.1`
+- the Redis settings stay on the legacy single Azure Cache for Redis endpoint for calver releases and semver releases earlier than `1.0.1`
+- the Redis settings switch to Azure Managed Redis with separate primary and Sidekiq endpoints for commit-hash tags and semver releases `>= 1.0.1`
+
+When Azure Managed Redis is selected, the generated file also renders:
+
+- `TFE_REDIS_SIDEKIQ_HOST`
+- `TFE_REDIS_SIDEKIQ_USE_AUTH`
+- `TFE_REDIS_SIDEKIQ_USE_TLS`
+
+You must still create the matching `TFE_REDIS_SIDEKIQ_PASSWORD` Kubernetes secret manually from the Terraform outputs.
+
+The module also provisions the Azure Managed Redis databases with the `EnterpriseCluster` clustering policy for these semver releases and commit-hash tags so TFE can use the Azure Managed Redis topology intended for standard Redis clients and avoid the redirect-driven `OSSCluster` behavior.
+
+The module-generated Helm overrides file derives `image.tag`, the Azure load balancer health probe path, and any Redis Sidekiq settings from `tfe_image_tag`. If you choose to stop using the generated file and manage your own Helm values file instead, keep those settings aligned with the TFE version you are deploying.
+
 ## Scaling TFE Pods
 
 To manage the number of pods running within your TFE deployment, set the value of the `replicaCount` key accordingly.
@@ -20,6 +42,7 @@ By default, the module-generated Helm overrides will create a Kubernetes service
 service:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check" # semver releases earlier than 1.2.1
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "<tfe-lb-subnet-name>"
     service.beta.kubernetes.io/azure-load-balancer-ipv4: <"lb-static-ip">  # Available private IP address from TFE load balancer subnet
   type: LoadBalancer
@@ -39,3 +62,33 @@ service:
 ```
 
 In this case, the service will automatically provision a public IP in Azure and assign it to the external Azure load balancer.
+
+For commit-hash tags and semver releases `>= 1.2.1`, update the health probe annotation to:
+
+```yaml
+service:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/api/v1/health/readiness"
+```
+
+## Redis
+
+For calver releases and semver releases earlier than `1.0.1`, the generated Helm overrides file renders the standard Redis settings:
+
+```yaml
+env:
+  variables:
+    TFE_REDIS_HOST: "<redis-host>:6380"
+    TFE_REDIS_USE_AUTH: true
+    TFE_REDIS_USE_TLS: true
+```
+
+For commit-hash tags and semver releases `>= 1.0.1`, the generated file also renders dedicated Sidekiq Redis settings for Azure Managed Redis:
+
+```yaml
+env:
+  variables:
+    TFE_REDIS_SIDEKIQ_HOST: "<sidekiq-redis-host>:10000"
+    TFE_REDIS_SIDEKIQ_USE_AUTH: true
+    TFE_REDIS_SIDEKIQ_USE_TLS: true
+```

--- a/docs/kubernetes-secrets.md
+++ b/docs/kubernetes-secrets.md
@@ -58,7 +58,8 @@ kubectl create secret generic tfe-secrets \
   --from-file=TFE_LICENSE=/path/to/tfe_license.hclic \
   --from-literal=TFE_ENCRYPTION_PASSWORD=<TFE_ENCRYPTION_PASSWORD> \
   --from-literal=TFE_DATABASE_PASSWORD=<TFE_DATABASE_PASSWORD> \
-  --from-literal=TFE_REDIS_PASSWORD=<TFE_REDIS_PASSWORD>
+  --from-literal=TFE_REDIS_PASSWORD=<TFE_REDIS_PASSWORD> \
+  --from-literal=TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY=<TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY>
 ```
 
 >📝 Note: Do not base64-encode these values; the `kubectl` command will do it for you.
@@ -72,7 +73,8 @@ kubectl create secret generic tfe-secrets \
   --from-literal=TFE_ENCRYPTION_PASSWORD=<TFE_ENCRYPTION_PASSWORD> \
   --from-literal=TFE_DATABASE_PASSWORD=<TFE_DATABASE_PASSWORD> \
   --from-literal=TFE_REDIS_PASSWORD=<TFE_REDIS_PASSWORD> \
-  --from-literal=TFE_REDIS_SIDEKIQ_PASSWORD=<TFE_REDIS_SIDEKIQ_PASSWORD>
+  --from-literal=TFE_REDIS_SIDEKIQ_PASSWORD=<TFE_REDIS_SIDEKIQ_PASSWORD> \
+  --from-literal=TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY=<TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY>
 ```
 
 #### TLS secrets

--- a/docs/kubernetes-secrets.md
+++ b/docs/kubernetes-secrets.md
@@ -19,9 +19,12 @@ Password: your HashiCorp Terraform Enterprise license file (_e.g._ `terraform.hc
 - `TFE_ENCRYPTION_PASSWORD` - generate this yourself; this is used to encrypt and decrypt TFE's embedded Vault root token and unseal key.
 - `TFE_DATABASE_PASSWORD` - obtain from Terraform module output named `tfe_database_password` or `tfe_database_password_base64` depending on the format you need.
 - `TFE_REDIS_PASSWORD` - obtain from Terraform module output named `tfe_redis_password` or `tfe_redis_password_base64` depending on the format you need.
+- `TFE_REDIS_SIDEKIQ_PASSWORD` - required only when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`; obtain from Terraform module output named `tfe_redis_sidekiq_password` or `tfe_redis_sidekiq_password_base64` depending on the format you need.
 - `TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY` - obtain from Terraform module output named `tfe_object_storage_azure_account_key` or `tfe_object_storage_azure_account_key_base64` depending on the format you need.
 
 >📝 Note: To show the value of a sensitive Terraform output, run `terraform output <output-name>`.
+
+>📝 Note: When `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1` and the module uses Azure Managed Redis, the generated Helm overrides also set `TFE_REDIS_USER=default` and `TFE_REDIS_SIDEKIQ_USER=default`. These usernames are required by Azure Managed Redis in addition to the corresponding passwords.
 
 ### 3. TLS Certificate and Private Key
 
@@ -60,6 +63,18 @@ kubectl create secret generic tfe-secrets \
 
 >📝 Note: Do not base64-encode these values; the `kubectl` command will do it for you.
 
+If `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`, add the Sidekiq Redis password as well:
+
+```sh
+kubectl create secret generic tfe-secrets \
+  --namespace=<TFE_NAMESPACE> \
+  --from-file=TFE_LICENSE=/path/to/tfe_license.hclic \
+  --from-literal=TFE_ENCRYPTION_PASSWORD=<TFE_ENCRYPTION_PASSWORD> \
+  --from-literal=TFE_DATABASE_PASSWORD=<TFE_DATABASE_PASSWORD> \
+  --from-literal=TFE_REDIS_PASSWORD=<TFE_REDIS_PASSWORD> \
+  --from-literal=TFE_REDIS_SIDEKIQ_PASSWORD=<TFE_REDIS_SIDEKIQ_PASSWORD>
+```
+
 #### TLS secrets
 
 ```sh
@@ -71,10 +86,11 @@ kubectl create secret tls tfe-certs \
 
 [🔙 to Post Steps (main README)](../README.md#post-steps)
 
-
 ## Appendix
 
 For visual representation purposes only, here is a Kubernetes manifest of the required secrets for a TFE deployment (the secrets that were created in the previous section).
+
+>📝 Note: Include `TFE_REDIS_SIDEKIQ_PASSWORD` only when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1` and the module is using Azure Managed Redis.
 
 ```yaml
 apiVersion: v1
@@ -98,6 +114,7 @@ data:
   TFE_ENCRYPTION_PASSWORD: <base64-encoded TFE encryption password>
   TFE_DATABASE_PASSWORD: <base64-encoded TFE PostgreSQL database password>
   TFE_REDIS_PASSWORD: <base64-encoded TFE Redis password>
+  TFE_REDIS_SIDEKIQ_PASSWORD: <base64-encoded TFE Sidekiq Redis password>
   TFE_OBJECT_STORAGE_AZURE_ACCOUNT_KEY: <base64-encoded TFE object storage account key>
 ---
 apiVersion: v1

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -36,7 +36,23 @@ The TFE configuration settings for your deployment are managed within your Helm 
 4. Run `helm upgrade` to create a new TFE release.
    
    ```sh
-   helm upgrade terraform-enterprise hashicorp/terraform-enterprise --namespace <TFE_NAMESPACE> --values </path/to/tfe_helm_overrides.yaml>
-   ```
+    helm upgrade terraform-enterprise hashicorp/terraform-enterprise --namespace <TFE_NAMESPACE> --values </path/to/tfe_helm_overrides.yaml>
+    ```
 
 5. Delete the existing TFE pod(s), allowing Kubernetes to reschedule new ones.
+
+## Version-aware generated settings
+
+The module-generated Helm overrides file derives several settings from `tfe_image_tag`:
+
+- `image.tag` is rendered directly from `tfe_image_tag`
+- the Azure load balancer health probe path switches from `/_health_check` to `/api/v1/health/readiness` for commit-hash tags and semver releases `>= 1.2.1`
+- the Redis configuration switches from a single legacy Azure Cache for Redis endpoint to Azure Managed Redis with separate primary and Sidekiq endpoints for commit-hash tags and semver releases `>= 1.0.1`
+
+When Azure Managed Redis is selected, the generated Helm overrides file also renders:
+
+- `TFE_REDIS_SIDEKIQ_HOST`
+- `TFE_REDIS_SIDEKIQ_USE_AUTH`
+- `TFE_REDIS_SIDEKIQ_USE_TLS`
+
+The corresponding `TFE_REDIS_SIDEKIQ_PASSWORD` value remains a Kubernetes secret that you must create separately.

--- a/docs/tfe-version-upgrades.md
+++ b/docs/tfe-version-upgrades.md
@@ -1,40 +1,54 @@
 # TFE Version Upgrades
 
-TFE follows a monthly release cadence. See the [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) page for full details on the releases. The process for upgrading your TFE instance to a new version involves updating the value of `image.tag` within your Helm overrides file, and then running `helm upgrade` on your TFE release during a maintenance window.
+TFE follows a monthly release cadence. See the [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) page for full details on the releases. In this module, the deployed TFE version is driven by the Terraform input `tfe_image_tag`, which also controls version-aware Helm readiness behavior and Redis backend selection.
+
+## Version-aware behaviors
+
+- calver releases and semver releases earlier than `1.0.1` stay on the legacy Azure Cache for Redis deployment
+- commit-hash tags and semver releases `>= 1.0.1` switch to Azure Managed Redis with separate primary and Sidekiq Redis endpoints
+- calver releases and semver releases earlier than `1.2.1` use `/_health_check`
+- commit-hash tags and semver releases `>= 1.2.1` use `/api/v1/health/readiness` for readiness checks and the Azure load balancer probe path
+
+If your upgrade crosses the `1.0.1` boundary, or if you move from a calver release to a commit-hash build, plan for the Redis backend change and create or update the `TFE_REDIS_SIDEKIQ_PASSWORD` Kubernetes secret from the Terraform outputs before running `helm upgrade`.
 
 ## Procedure
 
-1. Determine your desired version of TFE from the [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) page. The value that you need will be in the **Version** column of the table that is displayed. Ensure you are on the **Kubernetes** tab of the table. When determing your target TFE version to upgrade to, be sure to check if there are any required releases in between your current and target version (denoted by a `*` character in the table).
+1. Determine your desired version of TFE from the [Terraform Enterprise Releases](https://developer.hashicorp.com/terraform/enterprise/releases) page. Use the **Kubernetes** release version and confirm whether any required intermediate releases must be applied first.
 
-2. During a maintenance window, connect to your TFE pod(s) and gracefully drain the node(s), preventing them from being able to execute any new Terraform runs until the pod(s) are rescheduled or restarted.
-   
+2. During a maintenance window, connect to your TFE pod(s) and gracefully drain the node(s), preventing them from executing new Terraform runs until the pod(s) are rescheduled or restarted.
+
    Access the TFE command line (`tfectl`) within your TFE pod(s):
+
    ```sh
    kubectl exec --namespace <TFE_NAMESPACE> -it <TFE_POD_NAME> -- bash
    ```
 
    Gracefully stop work on all nodes:
+
    ```sh
    tfectl node drain --all
    ```
 
-   For more details on the above commands, see the following documentation:
-    - [Access the TFE command line](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/admin/admin-cli/cli-access)
-    - [Gracefully stop work on a node](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/admin/admin-cli/admin-cli#gracefully-stop-work-on-a-node)
+   For more details, see:
+   - [Access the TFE command line](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/admin/admin-cli/cli-access)
+   - [Gracefully stop work on a node](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/admin/admin-cli/admin-cli#gracefully-stop-work-on-a-node)
 
 3. Generate a backup of your PostgreSQL database.
 
-4. Update the value of `image.tag` to your target version within your Helm overrides file.
+4. Update `tfe_image_tag` in your Terraform configuration to the target version and run `terraform apply` so the module can regenerate the Helm overrides with the correct `image.tag`, readiness path, and Redis settings.
 
-   ```yaml
-   image:
-     tag: v202407-1
+   ```hcl
+   tfe_image_tag = "1.2.1"
    ```
 
-5. Run `helm upgrade` on your TFE release.
+5. If the upgrade switches to Azure Managed Redis, create or update the `TFE_REDIS_SIDEKIQ_PASSWORD` Kubernetes secret value using the `tfe_redis_sidekiq_password` Terraform output before continuing.
+
+6. Review the regenerated Helm overrides file and keep any local customizations that you manage outside the module-generated version.
+
+7. Run `helm upgrade` on your TFE release.
 
    ```sh
    helm upgrade terraform-enterprise hashicorp/terraform-enterprise --namespace <TFE_NAMESPACE> --values /path/to/tfe_helm_overrides.yaml
    ```
 
-6. Delete the existing TFE pod(s), allowing Kubernetes to reschedule new ones.
+8. Delete the existing TFE pod(s), allowing Kubernetes to reschedule new ones.

--- a/examples/existing-aks-cluster/README.md
+++ b/examples/existing-aks-cluster/README.md
@@ -11,6 +11,10 @@ module "tfe" {
   friendly_name_prefix = var.friendly_name_prefix
   common_tags          = var.common_tags
 
+  # --- TFE config settings --- #
+  tfe_fqdn      = var.tfe_fqdn
+  tfe_image_tag = var.tfe_image_tag
+
   # --- Networking --- #
   vnet_id         = var.vnet_id
   aks_subnet_id   = var.aks_subnet_id
@@ -41,7 +45,11 @@ module "tfe" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.94.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.67 |
+
+## Providers
+
+No providers.
 
 ## Modules
 
@@ -49,72 +57,92 @@ module "tfe" {
 |------|--------|---------|
 | <a name="module_tfe"></a> [tfe](#module\_tfe) | ../.. | n/a |
 
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL database and Redis cache. | `string` | n/a | yes |
-| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix for uniquely naming Azure resources. | `string` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of Resource Group to create for this TFE deployment. | `string` | n/a | yes |
-| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
-| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
-| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should resolve to the load balancer IP address and will be what clients use to access TFE. | `string` | n/a | yes |
-| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 | <a name="input_aks_api_server_authorized_ip_ranges"></a> [aks\_api\_server\_authorized\_ip\_ranges](#input\_aks\_api\_server\_authorized\_ip\_ranges) | List of IP ranges that are allowed to access the AKS API server (control plane). | `list(string)` | `[]` | no |
+| <a name="input_aks_default_node_pool_max_surge"></a> [aks\_default\_node\_pool\_max\_surge](#input\_aks\_default\_node\_pool\_max\_surge) | The maximum number of nodes that can be added during an upgrade. | `string` | `"10%"` | no |
+| <a name="input_aks_default_node_pool_name"></a> [aks\_default\_node\_pool\_name](#input\_aks\_default\_node\_pool\_name) | Name of default node pool. | `string` | `"default"` | no |
+| <a name="input_aks_default_node_pool_node_count"></a> [aks\_default\_node\_pool\_node\_count](#input\_aks\_default\_node\_pool\_node\_count) | Number of nodes to run in the AKS default node pool. | `number` | `2` | no |
+| <a name="input_aks_default_node_pool_vm_size"></a> [aks\_default\_node\_pool\_vm\_size](#input\_aks\_default\_node\_pool\_vm\_size) | Size of the virtual machines within the AKS default node pool. | `string` | `"Standard_D8ds_v5"` | no |
 | <a name="input_aks_dns_service_ip"></a> [aks\_dns\_service\_ip](#input\_aks\_dns\_service\_ip) | The IP address assigned to the AKS internal DNS service. | `string` | `"10.1.0.10"` | no |
-| <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version for AKS cluster. | `string` | `"1.29.0"` | no |
-| <a name="input_aks_node_pool_node_count"></a> [aks\_node\_pool\_node\_count](#input\_aks\_node\_pool\_node\_count) | The number of nodes in the node pool. | `number` | `2` | no |
-| <a name="input_aks_node_pool_vm_size"></a> [aks\_node\_pool\_vm\_size](#input\_aks\_node\_pool\_vm\_size) | The size of the Virtual Machine. | `string` | `"Standard_D4_v2"` | no |
+| <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version for AKS cluster. | `string` | `"1.29.6"` | no |
+| <a name="input_aks_oidc_issuer_enabled"></a> [aks\_oidc\_issuer\_enabled](#input\_aks\_oidc\_issuer\_enabled) | Boolean to enable OIDC issuer for the AKS cluster. | `bool` | `true` | no |
+| <a name="input_aks_role_based_access_control_enabled"></a> [aks\_role\_based\_access\_control\_enabled](#input\_aks\_role\_based\_access\_control\_enabled) | Boolean to enable Role-Based Access Control (RBAC) for the AKS cluster. | `bool` | `true` | no |
 | <a name="input_aks_service_cidr"></a> [aks\_service\_cidr](#input\_aks\_service\_cidr) | IP range for Kubernetes services that can be used by AKS cluster. | `string` | `"10.1.0.0/16"` | no |
 | <a name="input_aks_subnet_id"></a> [aks\_subnet\_id](#input\_aks\_subnet\_id) | Subnet ID for AKS cluster. | `string` | `null` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Azure Availability Zones to spread TFE resources across. | `set(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_aks_tfe_node_pool_name"></a> [aks\_tfe\_node\_pool\_name](#input\_aks\_tfe\_node\_pool\_name) | Name of TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `string` | `"tfeaksnodes"` | no |
+| <a name="input_aks_tfe_node_pool_node_count"></a> [aks\_tfe\_node\_pool\_node\_count](#input\_aks\_tfe\_node\_pool\_node\_count) | Number of nodes in the AKS TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `number` | `2` | no |
+| <a name="input_aks_tfe_node_pool_vm_size"></a> [aks\_tfe\_node\_pool\_vm\_size](#input\_aks\_tfe\_node\_pool\_vm\_size) | Size of virtual machines in the AKS TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `string` | `"Standard_D8ds_v5"` | no |
+| <a name="input_aks_workload_identity_enabled"></a> [aks\_workload\_identity\_enabled](#input\_aks\_workload\_identity\_enabled) | Boolean to enable Workload Identity for the AKS cluster. | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Azure availability zones to spread TFE resources across. | `set(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Map of common tags for taggable Azure resources. | `map(string)` | `{}` | no |
-| <a name="input_create_aks_cluster"></a> [create\_aks\_cluster](#input\_create\_aks\_cluster) | Boolean to create a new AKS cluster for this TFE deployment. | `bool` | `true` | no |
+| <a name="input_create_aks_cluster"></a> [create\_aks\_cluster](#input\_create\_aks\_cluster) | Boolean to create a new AKS cluster for this TFE deployment. | `bool` | `false` | no |
+| <a name="input_create_aks_tfe_node_pool"></a> [create\_aks\_tfe\_node\_pool](#input\_create\_aks\_tfe\_node\_pool) | Boolean to create a new node pool for TFE in the AKS cluster. | `bool` | `false` | no |
 | <a name="input_create_blob_storage_private_endpoint"></a> [create\_blob\_storage\_private\_endpoint](#input\_create\_blob\_storage\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for TFE Storage Account. | `bool` | `true` | no |
-| <a name="input_create_helm_overrides_output_file"></a> [create\_helm\_overrides\_output\_file](#input\_create\_helm\_overrides\_output\_file) | Boolean to generate a YAML file from template with Helm overrides values for TFE deployment. | `bool` | `false` | no |
+| <a name="input_create_helm_overrides_file"></a> [create\_helm\_overrides\_file](#input\_create\_helm\_overrides\_file) | Boolean to generate a YAML file from template with Helm overrides values for TFE deployment. | `bool` | `true` | no |
 | <a name="input_create_postgres_private_endpoint"></a> [create\_postgres\_private\_endpoint](#input\_create\_postgres\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for PostgreSQL Flexible Server. | `bool` | `true` | no |
 | <a name="input_create_redis_private_endpoint"></a> [create\_redis\_private\_endpoint](#input\_create\_redis\_private\_endpoint) | Boolean to create a private DNS zone and private endpoint for Redis cache. | `bool` | `true` | no |
-| <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new Resource Group for this TFE deployment. | `bool` | `true` | no |
-| <a name="input_create_tfe_dns_record"></a> [create\_tfe\_dns\_record](#input\_create\_tfe\_dns\_record) | Boolean to create a DNS record for TFE. When `true`, `dns_zone_name` is also required. | `bool` | `false` | no |
-| <a name="input_dns_zone_is_private"></a> [dns\_zone\_is\_private](#input\_dns\_zone\_is\_private) | Determines if Azure DNS zone provided via `dns_zone_name` is public or private. | `bool` | `false` | no |
-| <a name="input_is_govcloud_region"></a> [is\_govcloud\_region](#input\_is\_govcloud\_region) | Boolean indicating whether this TFE deployment is in an Azure Government Cloud region. | `bool` | `false` | no |
+| <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new resource group for this TFE deployment. | `bool` | `true` | no |
+| <a name="input_create_tfe_private_dns_record"></a> [create\_tfe\_private\_dns\_record](#input\_create\_tfe\_private\_dns\_record) | Boolean to create a DNS record for TFE in a private Azure DNS zone. A `private_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
+| <a name="input_create_tfe_public_dns_record"></a> [create\_tfe\_public\_dns\_record](#input\_create\_tfe\_public\_dns\_record) | Boolean to create a DNS record for TFE in a public Azure DNS zone. A `public_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
+| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL flexible server database. | `string` | n/a | yes |
+| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all Azure resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
+| <a name="input_is_govcloud_region"></a> [is\_govcloud\_region](#input\_is\_govcloud\_region) | Boolean indicating if this TFE deployment is in an Azure Government Cloud region. | `bool` | `false` | no |
 | <a name="input_is_secondary_region"></a> [is\_secondary\_region](#input\_is\_secondary\_region) | Boolean indicating whether this TFE deployment is for 'primary' region or 'secondary' region. | `bool` | `false` | no |
-| <a name="input_postgres_administrator_login"></a> [postgres\_administrator\_login](#input\_postgres\_administrator\_login) | Username for administrator login of PostreSQL database. | `string` | `"tfe"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
 | <a name="input_postgres_backup_retention_days"></a> [postgres\_backup\_retention\_days](#input\_postgres\_backup\_retention\_days) | Number of days to retain backups of PostgreSQL Flexible Server. | `number` | `35` | no |
 | <a name="input_postgres_create_mode"></a> [postgres\_create\_mode](#input\_postgres\_create\_mode) | Determines if the PostgreSQL Flexible Server is being created as a new server or as a replica. | `string` | `"Default"` | no |
 | <a name="input_postgres_enable_high_availability"></a> [postgres\_enable\_high\_availability](#input\_postgres\_enable\_high\_availability) | Boolean to enable `ZoneRedundant` high availability with PostgreSQL database. | `bool` | `false` | no |
 | <a name="input_postgres_geo_redundant_backup_enabled"></a> [postgres\_geo\_redundant\_backup\_enabled](#input\_postgres\_geo\_redundant\_backup\_enabled) | Boolean to enable PostreSQL geo-redundant backup configuration in paired Azure region. | `bool` | `true` | no |
+| <a name="input_postgres_maintenance_window"></a> [postgres\_maintenance\_window](#input\_postgres\_maintenance\_window) | Map of maintenance window settings for PostgreSQL flexible server. | `map(number)` | <pre>{<br/>  "day_of_week": 0,<br/>  "start_hour": 0,<br/>  "start_minute": 0<br/>}</pre> | no |
 | <a name="input_postgres_primary_availability_zone"></a> [postgres\_primary\_availability\_zone](#input\_postgres\_primary\_availability\_zone) | Number for the availability zone for the db to reside in | `number` | `1` | no |
 | <a name="input_postgres_secondary_availability_zone"></a> [postgres\_secondary\_availability\_zone](#input\_postgres\_secondary\_availability\_zone) | Number for the availability zone for the db to reside in for the secondary node | `number` | `2` | no |
-| <a name="input_postgres_sku"></a> [postgres\_sku](#input\_postgres\_sku) | PostgreSQL database SKU. | `string` | `"GP_Standard_D2ds_v4"` | no |
+| <a name="input_postgres_sku"></a> [postgres\_sku](#input\_postgres\_sku) | PostgreSQL database SKU. | `string` | `"GP_Standard_D4ds_v4"` | no |
 | <a name="input_postgres_storage_mb"></a> [postgres\_storage\_mb](#input\_postgres\_storage\_mb) | Storage capacity of PostgreSQL Flexible Server (unit is megabytes). | `number` | `65536` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL database version. | `number` | `15` | no |
+| <a name="input_private_dns_zone_name"></a> [private\_dns\_zone\_name](#input\_private\_dns\_zone\_name) | Name of existing private Azure DNS zone to create DNS record in. Required when `create_tfe_private_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_private_dns_zone_rg_name"></a> [private\_dns\_zone\_rg\_name](#input\_private\_dns\_zone\_rg\_name) | Name of Resource Group where `private_dns_zone_name` resides. Required when `create_tfe_private_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_public_dns_zone_name"></a> [public\_dns\_zone\_name](#input\_public\_dns\_zone\_name) | Name of existing public Azure DNS zone to create DNS record in. Required when `create_tfe_public_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_public_dns_zone_rg_name"></a> [public\_dns\_zone\_rg\_name](#input\_public\_dns\_zone\_rg\_name) | Name of Resource Group where `public_dns_zone_name` resides. Required when `public_dns_zone_name` is not `null`. | `string` | `null` | no |
 | <a name="input_redis_capacity"></a> [redis\_capacity](#input\_redis\_capacity) | The size of the Redis cache to deploy. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4. | `number` | `1` | no |
 | <a name="input_redis_enable_authentication"></a> [redis\_enable\_authentication](#input\_redis\_enable\_authentication) | Boolean to enable authentication to the Redis cache. | `bool` | `true` | no |
-| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for Redis cache. Must be `true` when `redis_enable_authentication` is `false`. | `bool` | `false` | no |
+| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for Redis cache. | `bool` | `false` | no |
 | <a name="input_redis_family"></a> [redis\_family](#input\_redis\_family) | The SKU family/pricing group to use. Valid values are C (for Basic/Standard SKU family) and P (for Premium). | `string` | `"P"` | no |
-| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | The Minimum TLS version to use when SSL authentication is used. | `string` | `"1.2"` | no |
-| <a name="input_redis_port"></a> [redis\_port](#input\_redis\_port) | The port to access redis on. If ssl only access is enabled, the default port is 6380. The non-ssl defualt port is 6379. | `string` | `"6380"` | no |
+| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | Minimum TLS version to use with Redis cache. | `string` | `"1.2"` | no |
 | <a name="input_redis_sku_name"></a> [redis\_sku\_name](#input\_redis\_sku\_name) | Which SKU of Redis to use. Options are 'Basic', 'Standard', or 'Premium'. | `string` | `"Premium"` | no |
-| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for Redis cache. | `string` | `null` | no |
+| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for Azure cache for Redis. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Redis cache version. Only the major version is needed. | `number` | `6` | no |
-| <a name="input_secondary_aks_subnet_id"></a> [secondary\_aks\_subnet\_id](#input\_secondary\_aks\_subnet\_id) | Used for storage account replication for secondary region deployments only. AKS subnet ID for TFE AKS cluster in secondary region. | `string` | `null` | no |
-| <a name="input_storage_account_ip_allow"></a> [storage\_account\_cidr\_allow](#input\_storage\_account\_cidr\_allow) | List of CIDRs allowed to access TFE Storage Account. | `list(string)` | `[]` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of resource group for this TFE deployment. Must be an existing resource group if `create_resource_group` is `false`. | `string` | n/a | yes |
+| <a name="input_secondary_aks_subnet_id"></a> [secondary\_aks\_subnet\_id](#input\_secondary\_aks\_subnet\_id) | AKS subnet ID of existing TFE AKS cluster in secondary region. Used to allow AKS TFE nodes in secondary region access to TFE storage account in primary region. | `string` | `null` | no |
+| <a name="input_storage_account_ip_allow"></a> [storage\_account\_ip\_allow](#input\_storage\_account\_ip\_allow) | List of CIDRs allowed to access TFE Storage Account. | `list(string)` | `[]` | no |
 | <a name="input_storage_account_public_network_access_enabled"></a> [storage\_account\_public\_network\_access\_enabled](#input\_storage\_account\_public\_network\_access\_enabled) | Boolean to enable public network access to Azure Blob Storage Account. Needs to be `true` for initial creation. Set to `false` after initial creation. | `bool` | `true` | no |
-| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Which type of replication to use for TFE Storage Account. | `string` | `"LRS"` | no |
+| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Which type of replication to use for TFE Storage Account. | `string` | `"ZRS"` | no |
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | PostgreSQL database name for TFE. | `string` | `"tfe"` | no |
-| <a name="input_tfe_image_name"></a> [tfe\_image\_name](#input\_tfe\_image\_name) | Name of the TFE container image. Only set this if you are hosting the TFE container image in your own custom repository. | `string` | `"hashicorp/terraform-enterprise"` | no |
-| <a name="input_tfe_image_repository"></a> [tfe\_image\_repository](#input\_tfe\_image\_repository) | Repository for the TFE image. Only set this if you are hosting the TFE container image in your own custom repository. | `string` | `"images.releases.hashicorp.com"` | no |
+| <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
+| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of PostgreSQL TFE database user to create. | `string` | `"tfe"` | no |
+| <a name="input_tfe_dns_record_target"></a> [tfe\_dns\_record\_target](#input\_tfe\_dns\_record\_target) | Target of the TFE DNS record. This should be the IP address that the TFE FQDN resolves to. | `string` | `null` | no |
+| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should eventually resolve to the TFE load balancer DNS name or IP address and will be what clients use to access TFE. | `string` | n/a | yes |
+| <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8080` | no |
+| <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8443` | no |
 | <a name="input_tfe_image_tag"></a> [tfe\_image\_tag](#input\_tfe\_image\_tag) | Tag for the TFE image. This represents the version of TFE to deploy. | `string` | `"v202402-1"` | no |
 | <a name="input_tfe_kube_namespace"></a> [tfe\_kube\_namespace](#input\_tfe\_kube\_namespace) | Kubernetes namespace for TFE deployment. | `string` | `"tfe"` | no |
 | <a name="input_tfe_kube_service_account"></a> [tfe\_kube\_service\_account](#input\_tfe\_kube\_service\_account) | Kubernetes service account for TFE deployment. | `string` | `"tfe"` | no |
-| <a name="input_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#input\_tfe\_object\_storage\_azure\_use\_msi) | Boolean to use a Managed Service Identity (MSI) for TFE blob storage authentication. Requires additional configuration in your AKS cluster related to AAD Pod Identity. | `bool` | `false` | no |
-| <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Used for secondary region deployments only. Resource group name of TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Used for secondary region deployments only. Storage account name of the TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_primary_storage_container_name"></a> [tfe\_primary\_storage\_container\_name](#input\_tfe\_primary\_storage\_container\_name) | Used for storage account replication for secondary region deployments only. Storage container name of the TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_private_dns_zone_name"></a> [tfe\_private\_dns\_zone\_name](#input\_tfe\_private\_dns\_zone\_name) | Name of existing Azure DNS zone to create DNS record in. Only valid if `create_dns_record` is `true`. | `string` | `null` | no |
-| <a name="input_tfe_private_dns_zone_rg"></a> [tfe\_private\_dns\_zone\_rg](#input\_tfe\_private\_dns\_zone\_rg) | Name of Resource Group where `private_dns_zone_name` resides. | `string` | `null` | no |
+| <a name="input_tfe_lb_subnet_id"></a> [tfe\_lb\_subnet\_id](#input\_tfe\_lb\_subnet\_id) | Subnet ID for TFE load balancer. This can be the same as the AKS subnet ID if desired. The TFE load balancer is created/managed by Helm/Kubernetes. | `string` | `null` | no |
+| <a name="input_tfe_metrics_http_port"></a> [tfe\_metrics\_http\_port](#input\_tfe\_metrics\_http\_port) | HTTP port number that the TFE metrics endpoint will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `9090` | no |
+| <a name="input_tfe_metrics_https_port"></a> [tfe\_metrics\_https\_port](#input\_tfe\_metrics\_https\_port) | HTTPS port number that the TFE metrics endpoint will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `9091` | no |
+| <a name="input_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#input\_tfe\_object\_storage\_azure\_use\_msi) | Boolean to use TFE user-assigned managed identity (MSI) to access TFE blob storage. If `true`, `aks_workload_identity_enabled` must also be `true`. | `bool` | `false` | no |
+| <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Name of existing resource group of TFE deployment in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Name of existing TFE storage account in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_tfe_primary_storage_container_name"></a> [tfe\_primary\_storage\_container\_name](#input\_tfe\_primary\_storage\_container\_name) | Name of existing TFE storage container (within TFE storage account) in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -133,4 +161,8 @@ module "tfe" {
 | <a name="output_tfe_redis_host"></a> [tfe\_redis\_host](#output\_tfe\_redis\_host) | ------------------------------------------------------------------------------ Redis Cache ------------------------------------------------------------------------------ |
 | <a name="output_tfe_redis_password"></a> [tfe\_redis\_password](#output\_tfe\_redis\_password) | n/a |
 | <a name="output_tfe_redis_password_base64"></a> [tfe\_redis\_password\_base64](#output\_tfe\_redis\_password\_base64) | n/a |
+| <a name="output_tfe_redis_sidekiq_host"></a> [tfe\_redis\_sidekiq\_host](#output\_tfe\_redis\_sidekiq\_host) | n/a |
+| <a name="output_tfe_redis_sidekiq_password"></a> [tfe\_redis\_sidekiq\_password](#output\_tfe\_redis\_sidekiq\_password) | n/a |
+| <a name="output_tfe_redis_sidekiq_password_base64"></a> [tfe\_redis\_sidekiq\_password\_base64](#output\_tfe\_redis\_sidekiq\_password\_base64) | n/a |
+| <a name="output_tfe_redis_sidekiq_use_auth"></a> [tfe\_redis\_sidekiq\_use\_auth](#output\_tfe\_redis\_sidekiq\_use\_auth) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/existing-aks-cluster/main.tf
+++ b/examples/existing-aks-cluster/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.116.0"
+      version = "~> 4.67"
     }
   }
 }
@@ -25,6 +25,7 @@ module "tfe" {
 
   # --- TFE config settings --- #
   tfe_fqdn                   = var.tfe_fqdn
+  tfe_image_tag              = var.tfe_image_tag
   create_helm_overrides_file = var.create_helm_overrides_file
 
   # --- Networking --- #

--- a/examples/existing-aks-cluster/outputs.tf
+++ b/examples/existing-aks-cluster/outputs.tf
@@ -67,3 +67,21 @@ output "tfe_redis_password_base64" {
   value     = module.tfe.tfe_redis_password_base64
   sensitive = true
 }
+
+output "tfe_redis_sidekiq_host" {
+  value = module.tfe.tfe_redis_sidekiq_host
+}
+
+output "tfe_redis_sidekiq_password" {
+  value     = module.tfe.tfe_redis_sidekiq_password
+  sensitive = true
+}
+
+output "tfe_redis_sidekiq_password_base64" {
+  value     = module.tfe.tfe_redis_sidekiq_password_base64
+  sensitive = true
+}
+
+output "tfe_redis_sidekiq_use_auth" {
+  value = module.tfe.tfe_redis_sidekiq_use_auth
+}

--- a/examples/existing-aks-cluster/terraform.tfvars.example
+++ b/examples/existing-aks-cluster/terraform.tfvars.example
@@ -10,6 +10,7 @@ common_tags = {
 
 # --- TFE config settings --- #
 tfe_fqdn                   = "<tfe-fqdn>"
+tfe_image_tag              = "v202402-1"
 create_helm_overrides_file = true # set to `false` after initial deploy
 
 # --- Networking --- #
@@ -24,4 +25,3 @@ tfe_database_password_keyvault_secret_name = "<tfe-database-password-key-vault-s
 
 # --- Object Storage --- #
 storage_account_ip_allow = ["<client-ip-addresses>"] # IP address(es) of machine you are running Terraform from to deploy TFE (without subnet masks)
-

--- a/examples/existing-aks-cluster/variables.tf
+++ b/examples/existing-aks-cluster/variables.tf
@@ -123,6 +123,21 @@ variable "create_helm_overrides_file" {
   default     = true
 }
 
+variable "tfe_image_tag" {
+  type        = string
+  description = "Tag for the TFE image. This may be a calver release tag, a semver release tag, or a Git commit hash."
+  default     = "v202402-1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9A-Fa-f]{7,40}$", var.tfe_image_tag))
+    )
+    error_message = "Value must be a supported TFE calver tag like `v202402-1`, a semver tag like `1.2.1`, or a Git commit hash like `1a2b3c4d`."
+  }
+}
+
 #------------------------------------------------------------------------------
 # Networking
 #------------------------------------------------------------------------------

--- a/examples/new-aks-cluster/README.md
+++ b/examples/new-aks-cluster/README.md
@@ -13,6 +13,10 @@ module "tfe" {
   friendly_name_prefix = var.friendly_name_prefix
   common_tags          = var.common_tags
 
+  # --- TFE config settings --- #
+  tfe_fqdn      = var.tfe_fqdn
+  tfe_image_tag = var.tfe_image_tag
+
   # --- Networking --- #
   vnet_id         = var.vnet_id
   aks_subnet_id   = var.aks_subnet_id
@@ -44,7 +48,11 @@ module "tfe" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.95.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.67 |
+
+## Providers
+
+No providers.
 
 ## Modules
 
@@ -52,77 +60,99 @@ module "tfe" {
 |------|--------|---------|
 | <a name="module_tfe"></a> [tfe](#module\_tfe) | ../.. | n/a |
 
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL database and Redis cache. | `string` | n/a | yes |
-| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix for uniquely naming Azure resources. | `string` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of Resource Group to create for this TFE deployment. | `string` | n/a | yes |
-| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
-| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
-| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should resolve to the load balancer IP address and will be what clients use to access TFE. | `string` | n/a | yes |
-| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 | <a name="input_aks_api_server_authorized_ip_ranges"></a> [aks\_api\_server\_authorized\_ip\_ranges](#input\_aks\_api\_server\_authorized\_ip\_ranges) | List of IP ranges that are allowed to access the AKS API server (control plane). | `list(string)` | `[]` | no |
+| <a name="input_aks_default_node_pool_max_surge"></a> [aks\_default\_node\_pool\_max\_surge](#input\_aks\_default\_node\_pool\_max\_surge) | The maximum number of nodes that can be added during an upgrade. | `string` | `"10%"` | no |
+| <a name="input_aks_default_node_pool_name"></a> [aks\_default\_node\_pool\_name](#input\_aks\_default\_node\_pool\_name) | Name of default node pool. | `string` | `"default"` | no |
+| <a name="input_aks_default_node_pool_node_count"></a> [aks\_default\_node\_pool\_node\_count](#input\_aks\_default\_node\_pool\_node\_count) | Number of nodes to run in the AKS default node pool. | `number` | `2` | no |
+| <a name="input_aks_default_node_pool_vm_size"></a> [aks\_default\_node\_pool\_vm\_size](#input\_aks\_default\_node\_pool\_vm\_size) | Size of the virtual machines within the AKS default node pool. | `string` | `"Standard_D8ds_v5"` | no |
 | <a name="input_aks_dns_service_ip"></a> [aks\_dns\_service\_ip](#input\_aks\_dns\_service\_ip) | The IP address assigned to the AKS internal DNS service. | `string` | `"10.1.0.10"` | no |
-| <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version for AKS cluster. | `string` | `"1.29.0"` | no |
-| <a name="input_aks_node_pool_node_count"></a> [aks\_node\_pool\_node\_count](#input\_aks\_node\_pool\_node\_count) | The number of nodes in the node pool. | `number` | `2` | no |
-| <a name="input_aks_node_pool_vm_size"></a> [aks\_node\_pool\_vm\_size](#input\_aks\_node\_pool\_vm\_size) | The size of the Virtual Machine. | `string` | `"Standard_D4_v2"` | no |
+| <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version for AKS cluster. | `string` | `"1.29.6"` | no |
+| <a name="input_aks_oidc_issuer_enabled"></a> [aks\_oidc\_issuer\_enabled](#input\_aks\_oidc\_issuer\_enabled) | Boolean to enable OIDC issuer for the AKS cluster. | `bool` | `true` | no |
+| <a name="input_aks_role_based_access_control_enabled"></a> [aks\_role\_based\_access\_control\_enabled](#input\_aks\_role\_based\_access\_control\_enabled) | Boolean to enable Role-Based Access Control (RBAC) for the AKS cluster. | `bool` | `true` | no |
 | <a name="input_aks_service_cidr"></a> [aks\_service\_cidr](#input\_aks\_service\_cidr) | IP range for Kubernetes services that can be used by AKS cluster. | `string` | `"10.1.0.0/16"` | no |
 | <a name="input_aks_subnet_id"></a> [aks\_subnet\_id](#input\_aks\_subnet\_id) | Subnet ID for AKS cluster. | `string` | `null` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Azure Availability Zones to spread TFE resources across. | `set(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_aks_tfe_node_pool_name"></a> [aks\_tfe\_node\_pool\_name](#input\_aks\_tfe\_node\_pool\_name) | Name of TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `string` | `"tfeaksnodes"` | no |
+| <a name="input_aks_tfe_node_pool_node_count"></a> [aks\_tfe\_node\_pool\_node\_count](#input\_aks\_tfe\_node\_pool\_node\_count) | Number of nodes in the AKS TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `number` | `2` | no |
+| <a name="input_aks_tfe_node_pool_vm_size"></a> [aks\_tfe\_node\_pool\_vm\_size](#input\_aks\_tfe\_node\_pool\_vm\_size) | Size of virtual machines in the AKS TFE node pool. Only valid when `create_aks_tfe_node_pool` is `true`. | `string` | `"Standard_D8ds_v5"` | no |
+| <a name="input_aks_workload_identity_enabled"></a> [aks\_workload\_identity\_enabled](#input\_aks\_workload\_identity\_enabled) | Boolean to enable Workload Identity for the AKS cluster. | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Azure availability zones to spread TFE resources across. | `set(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Map of common tags for taggable Azure resources. | `map(string)` | `{}` | no |
-| <a name="input_create_aks_cluster"></a> [create\_aks\_cluster](#input\_create\_aks\_cluster) | Boolean to create a new AKS cluster for this TFE deployment. | `bool` | `true` | no |
+| <a name="input_create_aks_cluster"></a> [create\_aks\_cluster](#input\_create\_aks\_cluster) | Boolean to create a new AKS cluster for this TFE deployment. | `bool` | `false` | no |
+| <a name="input_create_aks_tfe_node_pool"></a> [create\_aks\_tfe\_node\_pool](#input\_create\_aks\_tfe\_node\_pool) | Boolean to create a new node pool for TFE in the AKS cluster. | `bool` | `false` | no |
 | <a name="input_create_blob_storage_private_endpoint"></a> [create\_blob\_storage\_private\_endpoint](#input\_create\_blob\_storage\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for TFE Storage Account. | `bool` | `true` | no |
-| <a name="input_create_helm_overrides_output_file"></a> [create\_helm\_overrides\_output\_file](#input\_create\_helm\_overrides\_output\_file) | Boolean to generate a YAML file from template with Helm overrides values for TFE deployment. | `bool` | `false` | no |
+| <a name="input_create_helm_overrides_file"></a> [create\_helm\_overrides\_file](#input\_create\_helm\_overrides\_file) | Boolean to generate a YAML file from template with Helm overrides values for TFE deployment. | `bool` | `true` | no |
 | <a name="input_create_postgres_private_endpoint"></a> [create\_postgres\_private\_endpoint](#input\_create\_postgres\_private\_endpoint) | Boolean to create a private endpoint and private DNS zone for PostgreSQL Flexible Server. | `bool` | `true` | no |
 | <a name="input_create_redis_private_endpoint"></a> [create\_redis\_private\_endpoint](#input\_create\_redis\_private\_endpoint) | Boolean to create a private DNS zone and private endpoint for Redis cache. | `bool` | `true` | no |
-| <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new Resource Group for this TFE deployment. | `bool` | `true` | no |
-| <a name="input_create_tfe_dns_record"></a> [create\_tfe\_dns\_record](#input\_create\_tfe\_dns\_record) | Boolean to create a DNS record for TFE. When `true`, `dns_zone_name` is also required. | `bool` | `false` | no |
-| <a name="input_dns_zone_is_private"></a> [dns\_zone\_is\_private](#input\_dns\_zone\_is\_private) | Determines if Azure DNS zone provided via `dns_zone_name` is public or private. | `bool` | `false` | no |
-| <a name="input_is_govcloud_region"></a> [is\_govcloud\_region](#input\_is\_govcloud\_region) | Boolean indicating whether this TFE deployment is in an Azure Government Cloud region. | `bool` | `false` | no |
+| <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new resource group for this TFE deployment. | `bool` | `true` | no |
+| <a name="input_create_tfe_private_dns_record"></a> [create\_tfe\_private\_dns\_record](#input\_create\_tfe\_private\_dns\_record) | Boolean to create a DNS record for TFE in a private Azure DNS zone. A `private_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
+| <a name="input_create_tfe_public_dns_record"></a> [create\_tfe\_public\_dns\_record](#input\_create\_tfe\_public\_dns\_record) | Boolean to create a DNS record for TFE in a public Azure DNS zone. A `public_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
+| <a name="input_db_subnet_id"></a> [db\_subnet\_id](#input\_db\_subnet\_id) | Subnet ID for PostgreSQL flexible server database. | `string` | n/a | yes |
+| <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all Azure resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
+| <a name="input_is_govcloud_region"></a> [is\_govcloud\_region](#input\_is\_govcloud\_region) | Boolean indicating if this TFE deployment is in an Azure Government Cloud region. | `bool` | `false` | no |
 | <a name="input_is_secondary_region"></a> [is\_secondary\_region](#input\_is\_secondary\_region) | Boolean indicating whether this TFE deployment is for 'primary' region or 'secondary' region. | `bool` | `false` | no |
-| <a name="input_postgres_administrator_login"></a> [postgres\_administrator\_login](#input\_postgres\_administrator\_login) | Username for administrator login of PostreSQL database. | `string` | `"tfe"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for this TFE deployment. | `string` | n/a | yes |
 | <a name="input_postgres_backup_retention_days"></a> [postgres\_backup\_retention\_days](#input\_postgres\_backup\_retention\_days) | Number of days to retain backups of PostgreSQL Flexible Server. | `number` | `35` | no |
 | <a name="input_postgres_create_mode"></a> [postgres\_create\_mode](#input\_postgres\_create\_mode) | Determines if the PostgreSQL Flexible Server is being created as a new server or as a replica. | `string` | `"Default"` | no |
 | <a name="input_postgres_enable_high_availability"></a> [postgres\_enable\_high\_availability](#input\_postgres\_enable\_high\_availability) | Boolean to enable `ZoneRedundant` high availability with PostgreSQL database. | `bool` | `false` | no |
 | <a name="input_postgres_geo_redundant_backup_enabled"></a> [postgres\_geo\_redundant\_backup\_enabled](#input\_postgres\_geo\_redundant\_backup\_enabled) | Boolean to enable PostreSQL geo-redundant backup configuration in paired Azure region. | `bool` | `true` | no |
+| <a name="input_postgres_maintenance_window"></a> [postgres\_maintenance\_window](#input\_postgres\_maintenance\_window) | Map of maintenance window settings for PostgreSQL flexible server. | `map(number)` | <pre>{<br/>  "day_of_week": 0,<br/>  "start_hour": 0,<br/>  "start_minute": 0<br/>}</pre> | no |
 | <a name="input_postgres_primary_availability_zone"></a> [postgres\_primary\_availability\_zone](#input\_postgres\_primary\_availability\_zone) | Number for the availability zone for the db to reside in | `number` | `1` | no |
 | <a name="input_postgres_secondary_availability_zone"></a> [postgres\_secondary\_availability\_zone](#input\_postgres\_secondary\_availability\_zone) | Number for the availability zone for the db to reside in for the secondary node | `number` | `2` | no |
-| <a name="input_postgres_sku"></a> [postgres\_sku](#input\_postgres\_sku) | PostgreSQL database SKU. | `string` | `"GP_Standard_D2ds_v4"` | no |
+| <a name="input_postgres_sku"></a> [postgres\_sku](#input\_postgres\_sku) | PostgreSQL database SKU. | `string` | `"GP_Standard_D4ds_v4"` | no |
 | <a name="input_postgres_storage_mb"></a> [postgres\_storage\_mb](#input\_postgres\_storage\_mb) | Storage capacity of PostgreSQL Flexible Server (unit is megabytes). | `number` | `65536` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL database version. | `number` | `15` | no |
+| <a name="input_private_dns_zone_name"></a> [private\_dns\_zone\_name](#input\_private\_dns\_zone\_name) | Name of existing private Azure DNS zone to create DNS record in. Required when `create_tfe_private_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_private_dns_zone_rg_name"></a> [private\_dns\_zone\_rg\_name](#input\_private\_dns\_zone\_rg\_name) | Name of Resource Group where `private_dns_zone_name` resides. Required when `create_tfe_private_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_public_dns_zone_name"></a> [public\_dns\_zone\_name](#input\_public\_dns\_zone\_name) | Name of existing public Azure DNS zone to create DNS record in. Required when `create_tfe_public_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_public_dns_zone_rg_name"></a> [public\_dns\_zone\_rg\_name](#input\_public\_dns\_zone\_rg\_name) | Name of Resource Group where `public_dns_zone_name` resides. Required when `public_dns_zone_name` is not `null`. | `string` | `null` | no |
 | <a name="input_redis_capacity"></a> [redis\_capacity](#input\_redis\_capacity) | The size of the Redis cache to deploy. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4. | `number` | `1` | no |
 | <a name="input_redis_enable_authentication"></a> [redis\_enable\_authentication](#input\_redis\_enable\_authentication) | Boolean to enable authentication to the Redis cache. | `bool` | `true` | no |
-| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for Redis cache. Must be `true` when `redis_enable_authentication` is `false`. | `bool` | `false` | no |
+| <a name="input_redis_enable_non_ssl_port"></a> [redis\_enable\_non\_ssl\_port](#input\_redis\_enable\_non\_ssl\_port) | Boolean to enable port non-SSL port 6379 for Redis cache. | `bool` | `false` | no |
 | <a name="input_redis_family"></a> [redis\_family](#input\_redis\_family) | The SKU family/pricing group to use. Valid values are C (for Basic/Standard SKU family) and P (for Premium). | `string` | `"P"` | no |
-| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | The Minimum TLS version to use when SSL authentication is used. | `string` | `"1.2"` | no |
-| <a name="input_redis_port"></a> [redis\_port](#input\_redis\_port) | The port to access redis on. If ssl only access is enabled, the default port is 6380. The non-ssl defualt port is 6379. | `string` | `"6380"` | no |
+| <a name="input_redis_min_tls_version"></a> [redis\_min\_tls\_version](#input\_redis\_min\_tls\_version) | Minimum TLS version to use with Redis cache. | `string` | `"1.2"` | no |
 | <a name="input_redis_sku_name"></a> [redis\_sku\_name](#input\_redis\_sku\_name) | Which SKU of Redis to use. Options are 'Basic', 'Standard', or 'Premium'. | `string` | `"Premium"` | no |
-| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for Redis cache. | `string` | `null` | no |
+| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet ID for Azure cache for Redis. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Redis cache version. Only the major version is needed. | `number` | `6` | no |
-| <a name="input_secondary_aks_subnet_id"></a> [secondary\_aks\_subnet\_id](#input\_secondary\_aks\_subnet\_id) | Used for storage account replication for secondary region deployments only. AKS subnet ID for TFE AKS cluster in secondary region. | `string` | `null` | no |
-| <a name="input_storage_account_ip_allow"></a> [storage\_account\_cidr\_allow](#input\_storage\_account\_cidr\_allow) | List of CIDRs allowed to access TFE Storage Account. | `list(string)` | `[]` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of resource group for this TFE deployment. Must be an existing resource group if `create_resource_group` is `false`. | `string` | n/a | yes |
+| <a name="input_secondary_aks_subnet_id"></a> [secondary\_aks\_subnet\_id](#input\_secondary\_aks\_subnet\_id) | AKS subnet ID of existing TFE AKS cluster in secondary region. Used to allow AKS TFE nodes in secondary region access to TFE storage account in primary region. | `string` | `null` | no |
+| <a name="input_storage_account_ip_allow"></a> [storage\_account\_ip\_allow](#input\_storage\_account\_ip\_allow) | List of CIDRs allowed to access TFE Storage Account. | `list(string)` | `[]` | no |
 | <a name="input_storage_account_public_network_access_enabled"></a> [storage\_account\_public\_network\_access\_enabled](#input\_storage\_account\_public\_network\_access\_enabled) | Boolean to enable public network access to Azure Blob Storage Account. Needs to be `true` for initial creation. Set to `false` after initial creation. | `bool` | `true` | no |
-| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Which type of replication to use for TFE Storage Account. | `string` | `"LRS"` | no |
+| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Which type of replication to use for TFE Storage Account. | `string` | `"ZRS"` | no |
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | PostgreSQL database name for TFE. | `string` | `"tfe"` | no |
-| <a name="input_tfe_image_name"></a> [tfe\_image\_name](#input\_tfe\_image\_name) | Name of the TFE container image. Only set this if you are hosting the TFE container image in your own custom repository. | `string` | `"hashicorp/terraform-enterprise"` | no |
-| <a name="input_tfe_image_repository"></a> [tfe\_image\_repository](#input\_tfe\_image\_repository) | Repository for the TFE image. Only set this if you are hosting the TFE container image in your own custom repository. | `string` | `"images.releases.hashicorp.com"` | no |
+| <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
+| <a name="input_tfe_database_password_keyvault_id"></a> [tfe\_database\_password\_keyvault\_id](#input\_tfe\_database\_password\_keyvault\_id) | Resource ID of the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_database_password_keyvault_secret_name"></a> [tfe\_database\_password\_keyvault\_secret\_name](#input\_tfe\_database\_password\_keyvault\_secret\_name) | Name of the secret in the Key Vault that contains the TFE database password. | `string` | n/a | yes |
+| <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of PostgreSQL TFE database user to create. | `string` | `"tfe"` | no |
+| <a name="input_tfe_dns_record_target"></a> [tfe\_dns\_record\_target](#input\_tfe\_dns\_record\_target) | Target of the TFE DNS record. This should be the IP address that the TFE FQDN resolves to. | `string` | `null` | no |
+| <a name="input_tfe_fqdn"></a> [tfe\_fqdn](#input\_tfe\_fqdn) | Fully qualified domain name of TFE instance. This name should eventually resolve to the TFE load balancer DNS name or IP address and will be what clients use to access TFE. | `string` | n/a | yes |
+| <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8080` | no |
+| <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port number that the TFE application will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `8443` | no |
 | <a name="input_tfe_image_tag"></a> [tfe\_image\_tag](#input\_tfe\_image\_tag) | Tag for the TFE image. This represents the version of TFE to deploy. | `string` | `"v202402-1"` | no |
 | <a name="input_tfe_kube_namespace"></a> [tfe\_kube\_namespace](#input\_tfe\_kube\_namespace) | Kubernetes namespace for TFE deployment. | `string` | `"tfe"` | no |
 | <a name="input_tfe_kube_service_account"></a> [tfe\_kube\_service\_account](#input\_tfe\_kube\_service\_account) | Kubernetes service account for TFE deployment. | `string` | `"tfe"` | no |
-| <a name="input_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#input\_tfe\_object\_storage\_azure\_use\_msi) | Boolean to use a Managed Service Identity (MSI) for TFE blob storage authentication. Requires additional configuration in your AKS cluster related to AAD Pod Identity. | `bool` | `false` | no |
-| <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Used for secondary region deployments only. Resource group name of TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Used for secondary region deployments only. Storage account name of the TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_primary_storage_container_name"></a> [tfe\_primary\_storage\_container\_name](#input\_tfe\_primary\_storage\_container\_name) | Used for storage account replication for secondary region deployments only. Storage container name of the TFE deployment in primary region. | `string` | `null` | no |
-| <a name="input_tfe_private_dns_zone_name"></a> [tfe\_private\_dns\_zone\_name](#input\_tfe\_private\_dns\_zone\_name) | Name of existing Azure DNS zone to create DNS record in. Only valid if `create_dns_record` is `true`. | `string` | `null` | no |
-| <a name="input_tfe_private_dns_zone_rg"></a> [tfe\_private\_dns\_zone\_rg](#input\_tfe\_private\_dns\_zone\_rg) | Name of Resource Group where `private_dns_zone_name` resides. | `string` | `null` | no |
+| <a name="input_tfe_lb_subnet_id"></a> [tfe\_lb\_subnet\_id](#input\_tfe\_lb\_subnet\_id) | Subnet ID for TFE load balancer. This can be the same as the AKS subnet ID if desired. The TFE load balancer is created/managed by Helm/Kubernetes. | `string` | `null` | no |
+| <a name="input_tfe_metrics_http_port"></a> [tfe\_metrics\_http\_port](#input\_tfe\_metrics\_http\_port) | HTTP port number that the TFE metrics endpoint will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `9090` | no |
+| <a name="input_tfe_metrics_https_port"></a> [tfe\_metrics\_https\_port](#input\_tfe\_metrics\_https\_port) | HTTPS port number that the TFE metrics endpoint will listen on within the TFE pods. It is recommended to leave this as the default value. | `number` | `9091` | no |
+| <a name="input_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#input\_tfe\_object\_storage\_azure\_use\_msi) | Boolean to use TFE user-assigned managed identity (MSI) to access TFE blob storage. If `true`, `aks_workload_identity_enabled` must also be `true`. | `bool` | `false` | no |
+| <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Name of existing resource group of TFE deployment in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Name of existing TFE storage account in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_tfe_primary_storage_container_name"></a> [tfe\_primary\_storage\_container\_name](#input\_tfe\_primary\_storage\_container\_name) | Name of existing TFE storage container (within TFE storage account) in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
+| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VNet ID where TFE resources will reside. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aks_cluster_name"></a> [aks\_cluster\_name](#output\_aks\_cluster\_name) | ------------------------------------------------------------------------------ AKS ------------------------------------------------------------------------------ |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | ------------------------------------------------------------------------------ Resource group ------------------------------------------------------------------------------ |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | ------------------------------------------------------------------------------ Database ------------------------------------------------------------------------------ |
 | <a name="output_tfe_database_name"></a> [tfe\_database\_name](#output\_tfe\_database\_name) | n/a |
 | <a name="output_tfe_database_password"></a> [tfe\_database\_password](#output\_tfe\_database\_password) | n/a |
@@ -130,10 +160,14 @@ module "tfe" {
 | <a name="output_tfe_database_user"></a> [tfe\_database\_user](#output\_tfe\_database\_user) | n/a |
 | <a name="output_tfe_object_storage_azure_account_key"></a> [tfe\_object\_storage\_azure\_account\_key](#output\_tfe\_object\_storage\_azure\_account\_key) | n/a |
 | <a name="output_tfe_object_storage_azure_account_key_base64"></a> [tfe\_object\_storage\_azure\_account\_key\_base64](#output\_tfe\_object\_storage\_azure\_account\_key\_base64) | n/a |
-| <a name="output_tfe_object_storage_azure_account_name"></a> [tfe\_object\_storage\_azure\_account\_name](#output\_tfe\_object\_storage\_azure\_account\_name) | ------------------------------------------------------------------------------ Blob Storage ------------------------------------------------------------------------------ |
+| <a name="output_tfe_object_storage_azure_account_name"></a> [tfe\_object\_storage\_azure\_account\_name](#output\_tfe\_object\_storage\_azure\_account\_name) | ------------------------------------------------------------------------------ Object Storage ------------------------------------------------------------------------------ |
 | <a name="output_tfe_object_storage_azure_container"></a> [tfe\_object\_storage\_azure\_container](#output\_tfe\_object\_storage\_azure\_container) | n/a |
 | <a name="output_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#output\_tfe\_object\_storage\_azure\_use\_msi) | n/a |
-| <a name="output_tfe_redis_host"></a> [tfe\_redis\_host](#output\_tfe\_redis\_host) | ------------------------------------------------------------------------------ Redis Cache ------------------------------------------------------------------------------ |
+| <a name="output_tfe_redis_host"></a> [tfe\_redis\_host](#output\_tfe\_redis\_host) | ------------------------------------------------------------------------------ Redis ------------------------------------------------------------------------------ |
 | <a name="output_tfe_redis_password"></a> [tfe\_redis\_password](#output\_tfe\_redis\_password) | n/a |
 | <a name="output_tfe_redis_password_base64"></a> [tfe\_redis\_password\_base64](#output\_tfe\_redis\_password\_base64) | n/a |
+| <a name="output_tfe_redis_sidekiq_host"></a> [tfe\_redis\_sidekiq\_host](#output\_tfe\_redis\_sidekiq\_host) | n/a |
+| <a name="output_tfe_redis_sidekiq_password"></a> [tfe\_redis\_sidekiq\_password](#output\_tfe\_redis\_sidekiq\_password) | n/a |
+| <a name="output_tfe_redis_sidekiq_password_base64"></a> [tfe\_redis\_sidekiq\_password\_base64](#output\_tfe\_redis\_sidekiq\_password\_base64) | n/a |
+| <a name="output_tfe_redis_sidekiq_use_auth"></a> [tfe\_redis\_sidekiq\_use\_auth](#output\_tfe\_redis\_sidekiq\_use\_auth) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/new-aks-cluster/main.tf
+++ b/examples/new-aks-cluster/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.116.0"
+      version = "~> 4.67"
     }
   }
 }
@@ -26,6 +26,7 @@ module "tfe" {
 
   # --- TFE config settings --- #
   tfe_fqdn                   = var.tfe_fqdn
+  tfe_image_tag              = var.tfe_image_tag
   create_helm_overrides_file = var.create_helm_overrides_file
 
   # --- Networking --- #

--- a/examples/new-aks-cluster/outputs.tf
+++ b/examples/new-aks-cluster/outputs.tf
@@ -81,3 +81,21 @@ output "tfe_redis_password_base64" {
   value     = module.tfe.tfe_redis_password_base64
   sensitive = true
 }
+
+output "tfe_redis_sidekiq_host" {
+  value = module.tfe.tfe_redis_sidekiq_host
+}
+
+output "tfe_redis_sidekiq_password" {
+  value     = module.tfe.tfe_redis_sidekiq_password
+  sensitive = true
+}
+
+output "tfe_redis_sidekiq_password_base64" {
+  value     = module.tfe.tfe_redis_sidekiq_password_base64
+  sensitive = true
+}
+
+output "tfe_redis_sidekiq_use_auth" {
+  value = module.tfe.tfe_redis_sidekiq_use_auth
+}

--- a/examples/new-aks-cluster/terraform.tfvars.example
+++ b/examples/new-aks-cluster/terraform.tfvars.example
@@ -10,6 +10,7 @@ common_tags = {
 
 # --- TFE config settings --- #
 tfe_fqdn                   = "<tfe-fqdn>"
+tfe_image_tag              = "v202402-1"
 create_helm_overrides_file = true # set to `false` after initial deploy
 
 # --- Networking --- #

--- a/examples/new-aks-cluster/variables.tf
+++ b/examples/new-aks-cluster/variables.tf
@@ -123,6 +123,21 @@ variable "create_helm_overrides_file" {
   default     = true
 }
 
+variable "tfe_image_tag" {
+  type        = string
+  description = "Tag for the TFE image. This may be a calver release tag, a semver release tag, or a Git commit hash."
+  default     = "v202402-1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9A-Fa-f]{7,40}$", var.tfe_image_tag))
+    )
+    error_message = "Value must be a supported TFE calver tag like `v202402-1`, a semver tag like `1.2.1`, or a Git commit hash like `1a2b3c4d`."
+  }
+}
+
 #------------------------------------------------------------------------------
 # Networking
 #------------------------------------------------------------------------------

--- a/locals_helm_overrides.tf
+++ b/locals_helm_overrides.tf
@@ -5,6 +5,76 @@
 # Helm overrides values
 #------------------------------------------------------------------------------
 locals {
+  is_calver_tfe_image_tag      = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
+  normalized_tfe_image_tag     = trimprefix(var.tfe_image_tag, "v")
+  is_semver_tfe_image_tag      = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tfe_image_tag))
+  is_commit_hash_tfe_image_tag = can(regex("^[0-9A-Fa-f]{7,40}$", var.tfe_image_tag))
+  tfe_image_tag_parts          = local.is_semver_tfe_image_tag ? split(".", local.normalized_tfe_image_tag) : []
+  tfe_image_tag_major          = local.is_semver_tfe_image_tag ? tonumber(local.tfe_image_tag_parts[0]) : 0
+  tfe_image_tag_minor          = local.is_semver_tfe_image_tag ? tonumber(local.tfe_image_tag_parts[1]) : 0
+  tfe_image_tag_patch          = local.is_semver_tfe_image_tag && length(local.tfe_image_tag_parts) > 2 ? tonumber(local.tfe_image_tag_parts[2]) : 0
+
+  tfe_redis_uses_managed_redis = !var.is_govcloud_region && (
+    local.is_commit_hash_tfe_image_tag || (
+      local.is_semver_tfe_image_tag && (
+        local.tfe_image_tag_major > 1 || (
+          local.tfe_image_tag_major == 1 && (
+            local.tfe_image_tag_minor > 0 ||
+            (local.tfe_image_tag_minor == 0 && local.tfe_image_tag_patch >= 1)
+          )
+        )
+      )
+    )
+  )
+
+  tfe_readiness_uses_api = local.is_commit_hash_tfe_image_tag || (
+    local.is_semver_tfe_image_tag && (
+      local.tfe_image_tag_major > 1 || (
+        local.tfe_image_tag_major == 1 && (
+          local.tfe_image_tag_minor > 2 ||
+          (local.tfe_image_tag_minor == 2 && local.tfe_image_tag_patch >= 1)
+        )
+      )
+    )
+  )
+
+  tfe_health_check_path       = local.tfe_readiness_uses_api ? "/api/v1/health/readiness" : "/_health_check"
+  redis_private_dns_zone_name = local.tfe_redis_uses_managed_redis ? "privatelink.redis.azure.net" : (var.is_govcloud_region ? "privatelink.redis.cache.usgovcloudapi.net" : "privatelink.redis.cache.windows.net")
+
+  redis_private_endpoint_targets = var.create_redis_private_endpoint ? (
+    local.tfe_redis_uses_managed_redis ? {
+      main = {
+        resource_id      = azurerm_managed_redis.tfe[0].id
+        dns_record_name  = join(".", slice(split(".", azurerm_managed_redis.tfe[0].hostname), 0, length(split(".", azurerm_managed_redis.tfe[0].hostname)) - 3))
+        subresource_name = "redisEnterprise"
+      }
+      sidekiq = {
+        resource_id      = azurerm_managed_redis.tfe_sidekiq[0].id
+        dns_record_name  = join(".", slice(split(".", azurerm_managed_redis.tfe_sidekiq[0].hostname), 0, length(split(".", azurerm_managed_redis.tfe_sidekiq[0].hostname)) - 3))
+        subresource_name = "redisEnterprise"
+      }
+      } : {
+      main = {
+        resource_id      = azurerm_redis_cache.tfe[0].id
+        dns_record_name  = azurerm_redis_cache.tfe[0].name
+        subresource_name = "redisCache"
+      }
+    }
+  ) : {}
+
+  redis_main_default_database    = local.tfe_redis_uses_managed_redis ? try(azurerm_managed_redis.tfe[0].default_database[0], null) : null
+  redis_sidekiq_default_database = local.tfe_redis_uses_managed_redis ? try(azurerm_managed_redis.tfe_sidekiq[0].default_database[0], null) : null
+
+  redis_main_hostname = local.tfe_redis_uses_managed_redis ? azurerm_managed_redis.tfe[0].hostname : try(azurerm_redis_cache.tfe[0].hostname, "")
+  redis_main_port     = local.tfe_redis_uses_managed_redis ? coalesce(try(local.redis_main_default_database.port, null), 10000) : 6380
+  redis_main_use_auth = local.tfe_redis_uses_managed_redis ? coalesce(try(local.redis_main_default_database.access_keys_authentication_enabled, null), true) : try(azurerm_redis_cache.tfe[0].redis_configuration[0].authentication_enabled, false)
+  redis_main_user     = local.tfe_redis_uses_managed_redis ? "default" : ""
+
+  redis_sidekiq_hostname = local.tfe_redis_uses_managed_redis ? azurerm_managed_redis.tfe_sidekiq[0].hostname : ""
+  redis_sidekiq_port     = local.tfe_redis_uses_managed_redis ? coalesce(try(local.redis_sidekiq_default_database.port, null), 10000) : 0
+  redis_sidekiq_use_auth = local.tfe_redis_uses_managed_redis ? coalesce(try(local.redis_sidekiq_default_database.access_keys_authentication_enabled, null), true) : false
+  redis_sidekiq_user     = local.tfe_redis_uses_managed_redis ? "default" : ""
+
   helm_overrides_values = {
 
     # Service account annotation for AKS Azure AD workload identity
@@ -19,6 +89,8 @@ locals {
     tfe_https_port         = var.tfe_https_port
     tfe_metrics_http_port  = var.tfe_metrics_http_port
     tfe_metrics_https_port = var.tfe_metrics_https_port
+    tfe_image_tag          = var.tfe_image_tag
+    tfe_health_check_path  = local.tfe_health_check_path
 
     # Database settings
     tfe_database_host       = "${azurerm_postgresql_flexible_server.tfe.fqdn}:5432"
@@ -34,9 +106,15 @@ locals {
     tfe_object_storage_azure_client_id    = var.tfe_object_storage_azure_use_msi ? azurerm_user_assigned_identity.tfe[0].client_id : ""
 
     # Redis settings
-    tfe_redis_host     = try("${azurerm_redis_cache.tfe.hostname}:6380", "")
-    tfe_redis_use_auth = try(azurerm_redis_cache.tfe.redis_configuration[0].enable_authentication, "")
-    tfe_redis_use_tls  = true
+    tfe_redis_host                  = "${local.redis_main_hostname}:${local.redis_main_port}"
+    tfe_redis_user                  = local.redis_main_user
+    tfe_redis_use_auth              = local.redis_main_use_auth
+    tfe_redis_use_tls               = true
+    tfe_render_redis_sidekiq_values = local.tfe_redis_uses_managed_redis
+    tfe_redis_sidekiq_host          = local.tfe_redis_uses_managed_redis ? "${local.redis_sidekiq_hostname}:${local.redis_sidekiq_port}" : ""
+    tfe_redis_sidekiq_user          = local.tfe_redis_uses_managed_redis ? local.redis_sidekiq_user : ""
+    tfe_redis_sidekiq_use_auth      = local.tfe_redis_uses_managed_redis ? local.redis_sidekiq_use_auth : false
+    tfe_redis_sidekiq_use_tls       = local.tfe_redis_uses_managed_redis
   }
 }
 
@@ -53,4 +131,3 @@ resource "local_file" "helm_overrides_values" {
     ignore_changes = [content, filename]
   }
 }
-

--- a/locals_helm_overrides.tf
+++ b/locals_helm_overrides.tf
@@ -5,7 +5,6 @@
 # Helm overrides values
 #------------------------------------------------------------------------------
 locals {
-  is_calver_tfe_image_tag      = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
   normalized_tfe_image_tag     = trimprefix(var.tfe_image_tag, "v")
   is_semver_tfe_image_tag      = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tfe_image_tag))
   is_commit_hash_tfe_image_tag = can(regex("^[0-9A-Fa-f]{7,40}$", var.tfe_image_tag))

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,25 +81,47 @@ output "tfe_object_storage_azure_use_msi" {
 # Redis
 #------------------------------------------------------------------------------
 output "tfe_redis_host" {
-  value       = try(azurerm_redis_cache.tfe.hostname, null)
-  description = "Hostname of the Redis cache."
+  value       = local.tfe_redis_uses_managed_redis ? azurerm_managed_redis.tfe[0].hostname : azurerm_redis_cache.tfe[0].hostname
+  description = "Hostname of the primary Redis service used by TFE."
 }
 
 output "tfe_redis_password" {
-  value       = try(azurerm_redis_cache.tfe.primary_access_key, null)
-  description = "Primary access key of the Redis cache."
+  value       = local.tfe_redis_uses_managed_redis ? try(local.redis_main_default_database.primary_access_key, null) : azurerm_redis_cache.tfe[0].primary_access_key
+  description = "Primary access key of the primary Redis service used by TFE."
   sensitive   = true
 }
 
 output "tfe_redis_password_base64" {
-  value       = try(base64encode(azurerm_redis_cache.tfe.primary_access_key), null)
-  description = "Base64-encoded primary access key of the Redis cache."
+  value       = local.tfe_redis_uses_managed_redis ? (try(local.redis_main_default_database.primary_access_key, null) != null ? base64encode(local.redis_main_default_database.primary_access_key) : null) : base64encode(azurerm_redis_cache.tfe[0].primary_access_key)
+  description = "Base64-encoded primary access key of the primary Redis service used by TFE."
   sensitive   = true
 }
 
 output "tfe_redis_use_auth" {
-  value       = try(azurerm_redis_cache.tfe.redis_configuration[0].enable_authentication, null)
-  description = "Boolean indicating whether TFE is using authentication to access the Redis cache."
+  value       = local.tfe_redis_uses_managed_redis ? try(local.redis_main_default_database.access_keys_authentication_enabled, true) : azurerm_redis_cache.tfe[0].redis_configuration[0].authentication_enabled
+  description = "Boolean indicating whether TFE is using authentication to access the primary Redis service."
+}
+
+output "tfe_redis_sidekiq_host" {
+  value       = local.tfe_redis_uses_managed_redis ? azurerm_managed_redis.tfe_sidekiq[0].hostname : null
+  description = "Hostname of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected."
+}
+
+output "tfe_redis_sidekiq_password" {
+  value       = local.tfe_redis_uses_managed_redis ? try(local.redis_sidekiq_default_database.primary_access_key, null) : null
+  description = "Primary access key of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected."
+  sensitive   = true
+}
+
+output "tfe_redis_sidekiq_password_base64" {
+  value       = local.tfe_redis_uses_managed_redis ? (try(local.redis_sidekiq_default_database.primary_access_key, null) != null ? base64encode(local.redis_sidekiq_default_database.primary_access_key) : null) : null
+  description = "Base64-encoded primary access key of the Sidekiq Redis service used by TFE when Azure Managed Redis is selected."
+  sensitive   = true
+}
+
+output "tfe_redis_sidekiq_use_auth" {
+  value       = local.tfe_redis_uses_managed_redis ? try(local.redis_sidekiq_default_database.access_keys_authentication_enabled, true) : null
+  description = "Boolean indicating whether TFE is using authentication to access the Sidekiq Redis service when Azure Managed Redis is selected."
 }
 
 #------------------------------------------------------------------------------

--- a/redis.tf
+++ b/redis.tf
@@ -2,16 +2,18 @@
 # SPDX-License-Identifier: MPL-2.0
 
 #------------------------------------------------------------------------------
-# Redis cache
+# Redis
 #------------------------------------------------------------------------------
 resource "azurerm_redis_cache" "tfe" {
+  count = local.tfe_redis_uses_managed_redis ? 0 : 1
+
   name                          = "${var.friendly_name_prefix}-tfe-redis"
   resource_group_name           = local.resource_group_name
   location                      = var.location
   capacity                      = var.redis_capacity
   family                        = var.redis_family
   sku_name                      = var.redis_sku_name
-  enable_non_ssl_port           = var.redis_enable_non_ssl_port
+  non_ssl_port_enabled          = var.redis_enable_non_ssl_port
   minimum_tls_version           = var.redis_min_tls_version
   public_network_access_enabled = false
   subnet_id                     = var.create_redis_private_endpoint ? null : var.redis_subnet_id
@@ -19,8 +21,8 @@ resource "azurerm_redis_cache" "tfe" {
   zones                         = var.availability_zones
 
   redis_configuration {
-    enable_authentication = var.redis_enable_authentication
-    rdb_backup_enabled    = false
+    authentication_enabled = var.redis_enable_authentication
+    rdb_backup_enabled     = false
   }
 
   tags = merge(
@@ -29,17 +31,57 @@ resource "azurerm_redis_cache" "tfe" {
   )
 }
 
+resource "azurerm_managed_redis" "tfe" {
+  count = local.tfe_redis_uses_managed_redis ? 1 : 0
+
+  name                      = "${var.friendly_name_prefix}-tfe-redis"
+  resource_group_name       = local.resource_group_name
+  location                  = var.location
+  sku_name                  = var.redis_managed_sku_name
+  high_availability_enabled = var.redis_managed_high_availability_enabled
+  public_network_access     = "Disabled"
+
+  default_database {
+    access_keys_authentication_enabled = var.redis_enable_authentication
+    client_protocol                    = "Encrypted"
+    clustering_policy                  = "EnterpriseCluster"
+  }
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe-redis" },
+    var.common_tags
+  )
+}
+
+resource "azurerm_managed_redis" "tfe_sidekiq" {
+  count = local.tfe_redis_uses_managed_redis ? 1 : 0
+
+  name                      = "${var.friendly_name_prefix}-tfe-redis-sidekiq"
+  resource_group_name       = local.resource_group_name
+  location                  = var.location
+  sku_name                  = var.redis_managed_sku_name
+  high_availability_enabled = var.redis_managed_high_availability_enabled
+  public_network_access     = "Disabled"
+
+  default_database {
+    access_keys_authentication_enabled = var.redis_enable_authentication
+    client_protocol                    = "Encrypted"
+    clustering_policy                  = "EnterpriseCluster"
+  }
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe-redis-sidekiq" },
+    var.common_tags
+  )
+}
+
 #------------------------------------------------------------------------------
 # Private DNS zone and private endpoint
-#
-# See the Azure docs for up to date private DNS zone values:
-# https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#databases
-#
 #------------------------------------------------------------------------------
 resource "azurerm_private_dns_zone" "redis" {
   count = var.create_redis_private_endpoint ? 1 : 0
 
-  name                = var.is_govcloud_region ? "privatelink.redis.cache.usgovcloudapi.net" : "privatelink.redis.cache.windows.net"
+  name                = local.redis_private_dns_zone_name
   resource_group_name = local.resource_group_name
   tags                = var.common_tags
 }
@@ -55,33 +97,33 @@ resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
 }
 
 resource "azurerm_private_endpoint" "redis" {
-  count = var.create_redis_private_endpoint ? 1 : 0
+  for_each = local.redis_private_endpoint_targets
 
-  name                = "${var.friendly_name_prefix}-tfe-redis-private-endpoint"
+  name                = "${var.friendly_name_prefix}-tfe-redis-${each.key}-private-endpoint"
   resource_group_name = local.resource_group_name
   location            = var.location
   subnet_id           = var.redis_subnet_id
 
   private_service_connection {
-    name                           = "${var.friendly_name_prefix}-tfe-redis-private-connection"
-    private_connection_resource_id = azurerm_redis_cache.tfe.id
+    name                           = "${var.friendly_name_prefix}-tfe-redis-${each.key}-private-connection"
+    private_connection_resource_id = each.value.resource_id
     is_manual_connection           = false
-    subresource_names              = ["redisCache"]
+    subresource_names              = [each.value.subresource_name]
   }
 
   tags = merge(
-    { "Name" = "${var.friendly_name_prefix}-tfe-redis-private-endpoint" },
+    { "Name" = "${var.friendly_name_prefix}-tfe-redis-${each.key}-private-endpoint" },
     var.common_tags
   )
 }
 
 resource "azurerm_private_dns_a_record" "redis" {
-  count = var.create_redis_private_endpoint ? 1 : 0
+  for_each = local.redis_private_endpoint_targets
 
-  name                = azurerm_redis_cache.tfe.name
+  name                = each.value.dns_record_name
   resource_group_name = local.resource_group_name
   zone_name           = azurerm_private_dns_zone.redis[0].name
   ttl                 = 300
-  records             = [azurerm_private_endpoint.redis[0].private_service_connection[0].private_ip_address]
+  records             = [azurerm_private_endpoint.redis[each.key].private_service_connection[0].private_ip_address]
   tags                = var.common_tags
 }

--- a/templates/helm_overrides_values.yaml.tpl
+++ b/templates/helm_overrides_values.yaml.tpl
@@ -7,7 +7,7 @@ tls:
 image:
  repository: images.releases.hashicorp.com
  name: hashicorp/terraform-enterprise
- tag: <v202407-1>
+ tag: ${tfe_image_tag}
 
 %{ if tfe_object_storage_azure_use_msi ~}
 serviceAccount:
@@ -28,7 +28,7 @@ tfe:
 service:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /_health_check
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: ${tfe_health_check_path}
     service.beta.kubernetes.io/azure-load-balancer-ipv4: "<lb-static-ip>" # Available private IP address from TFE load balancer subnet
 %{ if tfe_lb_subnet_name != "" ~}
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "${tfe_lb_subnet_name}"
@@ -64,6 +64,15 @@ env:
 
     # Redis settings
     TFE_REDIS_HOST: ${tfe_redis_host}
+%{ if tfe_redis_user != "" ~}
+    TFE_REDIS_USER: ${tfe_redis_user}
+%{ endif ~}
     TFE_REDIS_USE_AUTH: ${tfe_redis_use_auth}
     TFE_REDIS_USE_TLS: ${tfe_redis_use_tls}
+%{ if tfe_render_redis_sidekiq_values ~}
+    TFE_REDIS_SIDEKIQ_HOST: ${tfe_redis_sidekiq_host}
+    TFE_REDIS_SIDEKIQ_USER: ${tfe_redis_sidekiq_user}
+    TFE_REDIS_SIDEKIQ_USE_AUTH: ${tfe_redis_sidekiq_use_auth}
+    TFE_REDIS_SIDEKIQ_USE_TLS: ${tfe_redis_sidekiq_use_tls}
+%{ endif ~}
     

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,21 @@ variable "create_helm_overrides_file" {
   default     = true
 }
 
+variable "tfe_image_tag" {
+  type        = string
+  description = "Tag for the TFE image. This may be a calver release tag, a semver release tag, or a Git commit hash and is used to select version-specific Helm readiness and Redis behavior."
+  default     = "v202402-1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9A-Fa-f]{7,40}$", var.tfe_image_tag))
+    )
+    error_message = "Value must be a supported TFE calver tag like `v202402-1`, a semver tag like `1.2.1`, or a Git commit hash like `1a2b3c4d`."
+  }
+}
+
 #------------------------------------------------------------------------------
 # Networking
 #------------------------------------------------------------------------------
@@ -150,7 +165,7 @@ variable "db_subnet_id" {
 
 variable "redis_subnet_id" {
   type        = string
-  description = "Subnet ID for Azure cache for Redis."
+  description = "Subnet ID for the Redis service used by TFE."
 }
 
 variable "secondary_aks_subnet_id" {
@@ -272,6 +287,12 @@ variable "aks_default_node_pool_vm_size" {
   type        = string
   description = "Size of the virtual machines within the AKS default node pool."
   default     = "Standard_D8ds_v5"
+}
+
+variable "aks_default_node_pool_temporary_name_for_rotation" {
+  type        = string
+  description = "Temporary name Azure uses when rotating the AKS default node pool during updates that replace the existing pool."
+  default     = null
 }
 
 variable "aks_default_node_pool_max_surge" {
@@ -522,11 +543,11 @@ variable "tfe_primary_storage_container_name" {
 }
 
 #------------------------------------------------------------------------------
-# Redis cache
+# Redis
 #------------------------------------------------------------------------------
 variable "redis_family" {
   type        = string
-  description = "The SKU family/pricing group to use. Valid values are C (for Basic/Standard SKU family) and P (for Premium)."
+  description = "The SKU family/pricing group to use for the legacy Azure Cache for Redis path. Valid values are C (for Basic/Standard SKU family) and P (for Premium)."
   default     = "P"
 
   validation {
@@ -537,7 +558,7 @@ variable "redis_family" {
 
 variable "redis_capacity" {
   type        = number
-  description = "The size of the Redis cache to deploy. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4."
+  description = "The size of the legacy Azure Cache for Redis deployment. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4."
   default     = 1
 
   validation {
@@ -548,7 +569,7 @@ variable "redis_capacity" {
 
 variable "redis_sku_name" {
   type        = string
-  description = "Which SKU of Redis to use. Options are 'Basic', 'Standard', or 'Premium'."
+  description = "Which SKU of Redis to use for the legacy Azure Cache for Redis path. Options are 'Basic', 'Standard', or 'Premium'."
   default     = "Premium"
 
   validation {
@@ -559,30 +580,52 @@ variable "redis_sku_name" {
 
 variable "redis_version" {
   type        = number
-  description = "Redis cache version. Only the major version is needed."
+  description = "Legacy Azure Cache for Redis version. Only the major version is needed."
   default     = 6
 }
 
 variable "redis_enable_authentication" {
   type        = bool
-  description = "Boolean to enable authentication to the Redis cache."
+  description = "Boolean to enable authentication to the Redis service used by TFE."
   default     = true
 }
 
 variable "redis_enable_non_ssl_port" {
   type        = bool
-  description = "Boolean to enable port non-SSL port 6379 for Redis cache."
+  description = "Boolean to enable port non-SSL port 6379 for the legacy Azure Cache for Redis path."
   default     = false
 }
 
 variable "redis_min_tls_version" {
   type        = string
-  description = "Minimum TLS version to use with Redis cache."
+  description = "Minimum TLS version to use with the legacy Azure Cache for Redis path."
   default     = "1.2"
 }
 
 variable "create_redis_private_endpoint" {
   type        = bool
-  description = "Boolean to create a private DNS zone and private endpoint for Redis cache."
+  description = "Boolean to create a private DNS zone and private endpoint for the Redis service used by TFE."
   default     = true
+}
+
+variable "redis_managed_sku_name" {
+  type        = string
+  description = "Managed Redis SKU to use when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1` and the module switches to Azure Managed Redis."
+  default     = "Balanced_B3"
+
+  validation {
+    condition     = length(trimspace(var.redis_managed_sku_name)) > 0
+    error_message = "Value must not be empty."
+  }
+}
+
+variable "redis_managed_high_availability_enabled" {
+  type        = bool
+  description = "Boolean to enable high availability for Azure Managed Redis instances when `tfe_image_tag` is a commit hash or a semver release `>= 1.0.1`."
+  default     = true
+
+  validation {
+    condition     = contains([true, false], var.redis_managed_high_availability_enabled)
+    error_message = "Value must be a boolean."
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.116"
+      version = ">= 4.60"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This pull request updates the documentation for the Terraform module to support both legacy Azure Cache for Redis and the new Azure Managed Redis service, introduces version-aware configuration for TFE Redis and health checks, and updates provider requirements. It also clarifies and expands input variable documentation, especially regarding Redis and TFE image versioning.

**Azure Redis Support and Version-aware Behavior:**

- Added documentation for Azure Managed Redis support, including new resources (`azurerm_managed_redis.tfe`, `azurerm_managed_redis.tfe_sidekiq`) and variables to control managed Redis deployment when `tfe_image_tag` is a commit hash or semver release `>= 1.0.1`. This includes high availability and SKU selection for managed Redis. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R239-R240) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R344)
- Updated NSG/firewall rules and input variable descriptions to distinguish between legacy Azure Cache for Redis and Azure Managed Redis, including port and variable differences. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R344)

**Version-aware TFE Configuration:**

- Documented that the module now generates Helm overrides and readiness/health check paths based on the `tfe_image_tag`, with clear instructions and notes for users on how to handle these changes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125-R130) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R184-R192)

**Provider Requirements:**

- Increased the required `azurerm` provider version from `~> 3.116` to `>= 4.60` to support new Azure Managed Redis resources.

**Input Variable Documentation Improvements:**

- Clarified and expanded required and optional input variables, especially for Redis, PostgreSQL, and general Azure resource configuration. Added new variables for managed Redis and TFE image tagging. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R273-R286) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R344)

**General Documentation Improvements:**

- Improved clarity and accuracy throughout the `README.md`, including updated resource lists and more precise descriptions for networking, secrets, and deployment steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125-R130) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R184-R192) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R273-R286)

These changes ensure the module is ready for both legacy and managed Redis deployments and that users are guided through deployment steps with version-specific instructions.

## Description
This PR adds Azure Managed Redis support to the AKS Terraform Enterprise module for newer TFE builds and updates the generated Helm behavior to follow the deployed TFE version.

The implementation introduces version-aware Redis and readiness handling, adds the Managed Redis outputs needed for Kubernetes secret creation, and updates examples and docs to reflect the new behavior. It also expands `tfe_image_tag` validation so the module accepts calver tags, semver tags, and Git commit-hash tags consistently.

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Ran `task terraform-docs` in `modules/terraform-azurerm-terraform-enterprise-aks-hvd`
- Ran `task test` in `modules/terraform-azurerm-terraform-enterprise-aks-hvd`
- Confirmed the module, both example configurations, and the existing `tmp/live/managed-redis-support/{prereqs,acme,aks}` roots complete the repository's existing `terraform fmt`, `terraform init`, and `terraform validate` workflow through the module task runner

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
- Managed Redis selection is now version-aware: semver releases `>= 1.0.1` and commit-hash tags use separate primary and Sidekiq Azure Managed Redis services, while older semver/calver releases stay on the legacy Azure Cache for Redis path.
- Readiness handling is also version-aware: semver releases `>= 1.2.1` and commit-hash tags use `/api/v1/health/readiness`; older releases keep `/_health_check`.
- The generated Helm values now render the Azure Managed Redis usernames (`TFE_REDIS_USER=default` and `TFE_REDIS_SIDEKIQ_USER=default`) and Sidekiq Redis connection settings when Managed Redis is selected.
- The Managed Redis databases are created with the `EnterpriseCluster` clustering policy.
- No spec files are included in this PR.
- This PR is being opened as a draft while live Azure Managed Redis authentication validation continues.
